### PR TITLE
merge-dependabot-bump-pr スキル移植と steering plan の追従

### DIFF
--- a/.ai-agent/steering/plan.md
+++ b/.ai-agent/steering/plan.md
@@ -12,14 +12,14 @@
 
 ## 進行中
 
-- merge-dependabot-bump-pr スキルの移植（次タスク候補）
+- `.claude-plugin/marketplace.json` の作成（次タスク候補）
 
 ## ロードマップ
 
 ### Phase 1: スキル移植と公開準備
 
 - [x] dotfiles から autodev-init スキル＋テンプレート群を移植（2026-04-26）
-- [ ] dotfiles から merge-dependabot-bump-pr スキルを移植
+- [x] dotfiles から merge-dependabot-bump-pr スキルを移植（2026-04-26）
 - [ ] `.claude-plugin/marketplace.json` の作成
 - [ ] `template/SKILL.md` の作成
 - [x] CLAUDE.md / README.md / LICENSE の作成

--- a/.ai-agent/steering/plan.md
+++ b/.ai-agent/steering/plan.md
@@ -8,7 +8,7 @@
 
 - リポジトリ作成
 - .ai-agent/ ディレクトリ構造の構築
-- steering ドキュメント（market.md, product.md, tech.md）の作成
+- steering ドキュメント 5 種（market.md, product.md, tech.md, plan.md, work.md）の作成
 
 ## 進行中
 
@@ -23,7 +23,7 @@
 - [ ] `.claude-plugin/marketplace.json` の作成
 - [ ] `template/SKILL.md` の作成
 - [x] CLAUDE.md / README.md / LICENSE の作成
-- [ ] GitHub リポジトリの公開
+- [x] GitHub リポジトリの公開
 
 ### Phase 2: 品質改善・標準化
 

--- a/.ai-agent/structure.md
+++ b/.ai-agent/structure.md
@@ -53,7 +53,8 @@ agent-skills/
 │   │           ├── autodev-start-new-task/
 │   │           ├── autodev-steering/
 │   │           └── autodev-switch-to-default/
-│   └── merge-dependabot-bump-pr/       # 【未作成】Dependabot PR マージスキル（移植予定）
+│   └── merge-dependabot-bump-pr/       # Dependabot PR マージスキル
+│       └── SKILL.md                    # メインスキル（バージョンバンプ PR の安全性レビュー＋マージ）
 ├── .claude-plugin/                     # 【未作成】プラグインマーケットプレイス定義
 ├── template/                           # 【未作成】スキル作成テンプレート
 ├── CLAUDE.md                           # Claude Code 向けプロジェクトガイド

--- a/.ai-agent/tasks/20260426-port-merge-dependabot-bump-pr-skill/README.md
+++ b/.ai-agent/tasks/20260426-port-merge-dependabot-bump-pr-skill/README.md
@@ -1,0 +1,42 @@
+# dotfiles からの merge-dependabot-bump-pr スキル移植
+
+## 目的・ゴール
+
+`merge-dependabot-bump-pr` スキルを本リポジトリの `skills/merge-dependabot-bump-pr/` に移植する。Phase 1 ロードマップの第 2 タスク。
+
+## 移植元
+
+- 本体: `~/.claude/skills/merge-dependabot-bump-pr/SKILL.md`（dotfiles の home-manager 経由でシンボリックリンク済み、146 行）
+
+## 移植先
+
+`skills/merge-dependabot-bump-pr/SKILL.md` に同名で配置する。
+
+## 実装方針
+
+1. **そのままコピー**を基本とする。dotfiles 側で運用実績のあるスキルをそのまま再利用する。
+2. コピー後、以下を確認・調整する:
+   - YAML フロントマター（`description`, `allowed-tools`）が正しい形式か
+   - dotfiles 固有のパス参照や記述があれば一般化する（autodev-init 移植時と同様）
+3. `.ai-agent/structure.md` の「【未作成】skills/merge-dependabot-bump-pr/」マーカーを更新
+4. `.ai-agent/steering/plan.md` のロードマップ該当項目をチェック済みに更新
+
+## 完了条件
+
+- [x] `skills/merge-dependabot-bump-pr/SKILL.md` が配置されている
+- [x] YAML フロントマターが妥当（`description` フィールド存在）
+- [x] dotfiles 固有の表現が残っていないことを確認（grep で検出ゼロ）
+- [x] `.ai-agent/structure.md` の該当マーカーを更新
+- [x] `.ai-agent/steering/plan.md` のロードマップ該当項目をチェック済みに更新
+
+## トリアージ結果
+
+- 判定: そのまま続行
+- 理由: ゴール明確 / 技術的不確実性低 / 1 変更セットで完結 / 数時間規模
+
+## 作業ログ
+
+- 2026-04-26: タスク開始。dotfiles 側のファイル構成（146 行 1 ファイル）を確認、移植計画を作成。
+- 2026-04-26: `skills/merge-dependabot-bump-pr/SKILL.md` を配置（146 行）。YAML フロントマター（`description`, `allowed-tools`）が正しい形式であることを確認。dotfiles 固有のパス（`mizunashi`, `Workspace/MyWork`, `nix/programs`, `home-manager`）が含まれていないことを `grep` で確認（検出ゼロ）。
+- 2026-04-26: `.ai-agent/structure.md` の【未作成】マーカーを更新。`.ai-agent/steering/plan.md` のロードマップ該当項目を完了済みに更新、進行中項目を次タスク候補（`.claude-plugin/marketplace.json` 作成）に置き換え。
+- 2026-04-26: タスク完了。本リポジトリは git リポジトリではないため、PR 作成手順はスキップ。

--- a/skills/merge-dependabot-bump-pr/SKILL.md
+++ b/skills/merge-dependabot-bump-pr/SKILL.md
@@ -1,0 +1,145 @@
+---
+description: Review and merge a Dependabot bump PR after safety checks. Use when Dependabot has created version bump PRs and you want to review and merge them.
+allowed-tools: Read, Glob, Grep, "Bash(git remote get-url *)", WebSearch, WebFetch, AskUserQuestion, mcp__github__list_pull_requests, mcp__github__pull_request_read, mcp__github__merge_pull_request, mcp__github__get_latest_release, mcp__github__get_release_by_tag, mcp__github__search_issues, mcp__github__get_file_contents, mcp__github__list_commits
+---
+
+# Dependabot Bump PR のレビュー＆マージ
+
+dependabot が自動作成したバージョンバンプ PR をレビューし、安全と判断できればマージします。
+
+## 手順
+
+### 1. リポジトリ情報の取得
+
+- `git remote get-url origin` から owner/repo を特定
+
+### 2. 対象 PR の特定
+
+- `$ARGUMENTS` が指定されている場合: その PR 番号を使用
+- `$ARGUMENTS` が空の場合:
+  1. `mcp__github__list_pull_requests` で オープン PR を一覧取得
+  2. 結果から author が `dependabot[bot]` の PR をフィルタ
+  3. dependabot PR が複数ある場合は AskUserQuestion で対象を選択
+  4. dependabot PR が1つもない場合は「対象 PR がありません」と報告して終了
+
+### 3. PR 情報の取得
+
+- `mcp__github__pull_request_read` で PR の基本情報を取得（method: `get`）
+- タイトル・説明からパッケージ名とバージョン（旧 → 新）を特定
+  - dependabot の PR タイトルは通常 "Bump {package} from {old} to {new}" 形式
+- `mcp__github__pull_request_read` で差分を取得（method: `get_diff`）
+
+### 4. パッケージ情報の特定
+
+PR 情報から以下を抽出:
+
+- **パッケージのリポジトリ**: owner/repo 形式
+  - GitHub Actions の場合: `uses: owner/repo@tag` から特定
+  - npm / pip 等の場合: パッケージ名から GitHub リポジトリを WebSearch で特定
+- **新バージョン**: バンプ先のバージョン番号またはタグ
+
+### 5. レビュー: リリース経過日数の確認
+
+新バージョンがリリースされてから **1週間以上** 経過しているか確認する。
+
+- `mcp__github__get_release_by_tag` または `mcp__github__get_latest_release` でリリース情報を取得
+  - GitHub Actions の場合: タグ名は `v{version}` 形式が多い
+- リリース日（`published_at`）から現在までの経過日数を計算
+- **判定**:
+  - 7日以上経過: PASS
+  - 7日未満: WARN（「リリースから {N}日 しか経過していません」）
+  - リリース情報が取得できない: WARN（「リリース日を確認できませんでした」）
+
+### 6. レビュー: 致命的バグ報告の確認
+
+新バージョンに対する致命的なバグ報告がないか確認する。
+
+- `mcp__github__search_issues` でパッケージリポジトリの Issue を検索
+  - キーワード: 新バージョン番号 + `bug` / `regression` / `breaking`
+  - `state: "open"` で検索
+- 致命的と思われる Issue がある場合は内容を確認
+- **判定**:
+  - 致命的バグ報告なし: PASS
+  - 致命的バグ報告あり: FAIL（Issue のタイトルと URL を報告）
+  - 判断が難しい場合: WARN（Issue 情報を添えて報告）
+
+### 7. レビュー: リリースノートの確認
+
+リリースノートに注意すべき変更がないか確認する。
+
+- 手順5で取得したリリース情報の `body`（リリースノート）を確認
+- 以下の点を重点的にチェック:
+  - **Breaking changes**: 破壊的変更の有無
+  - **Deprecation**: 非推奨化の案内
+  - **Security advisories**: セキュリティ修正（あれば早めのマージを推奨）
+  - **Migration required**: マイグレーションが必要な変更
+- **判定**:
+  - 注意すべき変更なし: PASS
+  - Breaking changes / Migration required あり: FAIL（詳細を報告）
+  - Deprecation のみ: WARN（内容を報告）
+  - Security fix: PASS（早期マージ推奨として報告）
+
+### 8. レビュー: パッケージの差分の安全性確認
+
+パッケージの旧バージョンから新バージョンへのソースコード差分に、マルウェアや不審なコードが含まれていないか確認する。
+
+- パッケージリポジトリの旧バージョンと新バージョンの比較ページを WebFetch で取得
+  - `https://github.com/{owner}/{repo}/compare/{old_tag}...{new_tag}` を使用
+- 差分が大きい場合は `mcp__github__list_commits` で新旧タグ間のコミット一覧を取得し、各コミットの概要を確認
+- 以下の観点で精査:
+  - 難読化されたコード（Base64 エンコード、eval、動的コード生成）が追加されていないか
+  - 外部への通信（未知のドメインへの HTTP リクエスト、データ送信）が追加されていないか
+  - 環境変数やシークレットの読み取り・送信が追加されていないか
+  - ファイルシステムへの想定外のアクセス（ホームディレクトリ、SSH 鍵、認証情報の読み取り等）がないか
+  - パッケージの目的に不釣り合いな権限の要求や機能の追加がないか
+- **判定**:
+  - 不審なコードなし: PASS
+  - 不審なコードあり: FAIL（該当コードと懸念点を報告）
+  - 差分が大きすぎて全量確認が困難: WARN（確認できた範囲と未確認の範囲を報告）
+
+### 9. レビュー結果の報告
+
+4観点の結果をまとめてユーザーに報告する。
+
+```
+## レビュー結果: {PR タイトル}
+
+| 観点               | 判定 | 詳細                        |
+| ------------------ | ---- | --------------------------- |
+| リリース経過日数   | PASS | リリースから {N}日 経過      |
+| 致命的バグ報告     | PASS | 報告なし                    |
+| リリースノート     | PASS | 注意すべき変更なし          |
+| 差分の安全性       | PASS | バージョン番号の変更のみ    |
+
+**総合判定**: PASS — マージ可能です
+```
+
+### 10. マージ判定とユーザー確認
+
+総合判定に基づいて分岐:
+
+- **全て PASS の場合**:
+  - AskUserQuestion でマージの最終確認（「マージしてよいですか？」）
+  - ユーザーが承認したらマージ
+
+- **WARN を含む場合**:
+  - WARN の内容を強調して提示
+  - AskUserQuestion でユーザーの判断を仰ぐ（「WARN がありますがマージしますか？」）
+  - ユーザーが承認したらマージ
+
+- **FAIL を含む場合**:
+  - 「以下の理由でマージを推奨しません」と報告
+  - マージせずにスキル終了
+  - ユーザーが明示的にマージを指示した場合のみマージ可
+
+### 11. マージ実行
+
+- `mcp__github__merge_pull_request` でマージ
+  - `merge_method: "merge"`（マージコミット方式）
+- マージ完了後、PR URL と結果を報告
+
+## 注意事項
+
+- dependabot 以外の PR が指定された場合は、その旨を警告してからレビューを続行するか確認
+- パッケージリポジトリの情報取得に失敗した場合は WARN として扱い、ユーザーに判断を委ねる
+- リリースノートが長大な場合は重要な変更点のみ抜粋して報告


### PR DESCRIPTION
## 目的

- `merge-dependabot-bump-pr` スキルを dotfiles から本リポジトリへ移植する（plan.md Phase 1 第 2 タスク）
- `/autodev-steering` で検出した plan.md の陳腐化箇所を最新化する

## 変更概要

### Commit 1: Port merge-dependabot-bump-pr skill from dotfiles
- `skills/merge-dependabot-bump-pr/SKILL.md`（146 行）を新規追加
- `.ai-agent/structure.md` の【未作成】マーカーを除去し、新スキルの構成を反映
- `.ai-agent/steering/plan.md` のロードマップを更新（merge-dependabot-bump-pr 移植を完了済みに、進行中項目を `.claude-plugin/marketplace.json` 作成に置換）
- 移植タスクの README（`.ai-agent/tasks/20260426-port-merge-dependabot-bump-pr-skill/`）を追加

### Commit 2: Refresh steering plan to match current state
- 完了済みリスト: 「steering ドキュメント（market.md, product.md, tech.md）の作成」 → 「steering ドキュメント 5 種（…, plan.md, work.md）の作成」（実態は 5 ファイルとも作成済み）
- ロードマップ: `[ ] GitHub リポジトリの公開` → `[x]`（`gh repo view` で `visibility: PUBLIC` 確認済み）

## テストプラン

- [ ] `skills/merge-dependabot-bump-pr/SKILL.md` の YAML フロントマターが妥当か（`description`, `allowed-tools` フィールドの形式）
- [ ] `.ai-agent/structure.md` のディレクトリツリーが実体と一致するか
- [ ] `.ai-agent/steering/plan.md` の完了状態が現状を反映しているか