### PR TITLE
agent-coach プラグインに analytics 系特化スキル 2 種を追加

### DIFF
--- a/.ai-agent/structure.md
+++ b/.ai-agent/structure.md
@@ -22,7 +22,7 @@ agent-skills/
 │       └── 20260426-claude-code-best-practices/                # Claude Code ベストプラクティス調査（agent-coach の根拠リファレンス）
 ├── .claude/                                                    # Claude Code 設定
 │   ├── settings.local.json                                     # ローカル設定
-│   └── skills/                                                 # 開発用スキル（autodev シリーズ）
+│   └── skills/                                                 # 開発用スキル（autodev シリーズ + plugins への symlink）
 │       ├── autodev-create-issue/                               # GitHub Issue 作成
 │       ├── autodev-create-pr/                                  # PR 作成
 │       ├── autodev-discussion/                                 # 対話的アイデア整理
@@ -35,7 +35,8 @@ agent-skills/
 │       ├── autodev-start-new-survey/                           # 技術調査開始
 │       ├── autodev-start-new-task/                             # タスク開始（トリアージ付き）
 │       ├── autodev-steering/                                   # steering ドキュメント更新
-│       └── autodev-switch-to-default/                          # デフォルトブランチ切り替え
+│       ├── autodev-switch-to-default/                          # デフォルトブランチ切り替え
+│       └── recommend-bash-allowlist/                           # → plugins/agent-coach/.../SKILL.md への symlink（本リポジトリ自体での試用）
 ├── .claude-plugin/                                             # プラグインマーケットプレイス定義
 │   └── marketplace.json
 ├── plugins/                                                    # 公開プラグイン本体
@@ -67,8 +68,10 @@ agent-skills/
 │   └── agent-coach/                                            # agent-coach プラグイン
 │       ├── .claude-plugin/plugin.json
 │       └── skills/
-│           └── agent-coach/
-│               └── SKILL.md                                    # transcript 分析によるプロンプト・スキル・メモリ改善提案
+│           ├── agent-coach/
+│           │   └── SKILL.md                                    # transcript 分析によるプロンプト・スキル・メモリ改善提案
+│           └── recommend-bash-allowlist/
+│               └── SKILL.md                                    # auto / bypassPermissions モード下の Bash 実績から allowlist 推薦
 ├── template/                                                   # スキル作成テンプレート
 │   └── SKILL.md                                                # YAML フロントマター + 本文セクション雛形
 ├── schemas/                                                    # JSON Schema 定義

--- a/.ai-agent/structure.md
+++ b/.ai-agent/structure.md
@@ -36,6 +36,7 @@ agent-skills/
 │       ├── autodev-start-new-task/                             # タスク開始（トリアージ付き）
 │       ├── autodev-steering/                                   # steering ドキュメント更新
 │       ├── autodev-switch-to-default/                          # デフォルトブランチ切り替え
+│       ├── detect-context-rot/                                 # → plugins/agent-coach/.../SKILL.md への symlink（本リポジトリ自体での試用）
 │       └── recommend-bash-allowlist/                           # → plugins/agent-coach/.../SKILL.md への symlink（本リポジトリ自体での試用）
 ├── .claude-plugin/                                             # プラグインマーケットプレイス定義
 │   └── marketplace.json
@@ -70,6 +71,8 @@ agent-skills/
 │       └── skills/
 │           ├── agent-coach/
 │           │   └── SKILL.md                                    # transcript 分析によるプロンプト・スキル・メモリ改善提案
+│           ├── detect-context-rot/
+│           │   └── SKILL.md                                    # コンテキストロット深掘り（rot 始点推定 + クロスセッション傾向 + A〜E 改善提案）
 │           └── recommend-bash-allowlist/
 │               └── SKILL.md                                    # auto / bypassPermissions モード下の Bash 実績から allowlist 推薦
 ├── template/                                                   # スキル作成テンプレート

--- a/.ai-agent/tasks/20260505-add-bash-allowlist-recommender-skill/README.md
+++ b/.ai-agent/tasks/20260505-add-bash-allowlist-recommender-skill/README.md
@@ -1,0 +1,62 @@
+# Bash 許可リスト推薦スキルの追加
+
+## 目的・ゴール
+
+`plugins/agent-coach/` プラグインに、ユーザーの transcript を分析して `permissions.allow` に未登録の Bash コマンドパターンを抽出・推薦するスキルを追加する。
+
+ユーザーが auto mode で運用していると、`permissions.allow` に含まれていない Bash コマンドもプロンプトなしで実行される。「実際に走った」コマンドのうち allowlist 化していないパターンを一覧化することで、他のモード（default / acceptEdits）に切り替えても同等の体験を得るための allowlist 整備を支援する。
+
+## 実装方針
+
+### スキル配置
+
+- ディレクトリ: `plugins/agent-coach/skills/recommend-bash-allowlist/`
+- 本体: `SKILL.md`
+- agent-coach プラグインに同居（同プラグインは「Claude Code 利用ログを分析して改善提案する」軸）
+
+### 分析ロジック（SKILL.md に記述）
+
+1. **対象セッション特定**: agent-coach と同じ規約（cwd → `~/.claude/projects/<encoded-cwd>/` 配下、最新 N セッション、実行中セッションは除外）
+2. **permission-mode 区間の構築**: `type == "permission-mode"` のレコードを順に走査し、各セッションで「あるターン時点の permissionMode」を判定
+3. **Bash tool_use 抽出**: 各 `tool_use` (name=Bash) について、その時点の permissionMode を割り当てる
+4. **対象モードの絞り込**: `auto` および `bypassPermissions` 下で実行されたコマンドのみ
+5. **allowlist 突合**: 現在の `permissions.allow` を以下から取得して結合
+   - `~/.claude/settings.json`
+   - `<repo>/.claude/settings.json`
+   - `<repo>/.claude/settings.local.json`
+   - 各エントリは `Bash(<prefix>:*)` 形式 — 同形式で前方一致判定
+6. **prefix 粒度**: readonly/write の判別が可能な深さで抽出
+   - 単純コマンド（`ls`, `cat`, `find`, `grep` 等）→ 1 トークン
+   - サブコマンド体系のツール（`git`, `gh`, `npm`, `aws`, `kubectl`, `docker`, `brew`, `mas`, `nix`, `npx`, `pnpm`, `yarn`, `cargo`, `gcloud`, `az`, `terraform` 等）→ 2〜3 トークン
+   - 既存 allowlist 慣例に合わせる（`Bash(git log:*)`, `Bash(aws s3 ls:*)`, `Bash(gh pr view:*)` など）
+7. **readonly/write 分類**: prefix を curated キーワードで分類（log/status/show/view/get/list/diff/describe/check/test/lint → readonly、install/add/push/commit/merge/rm/mv/cp/delete/remove/update/create/build/exec → write、その他 → unknown）
+
+### 出力形式
+
+agent-coach 同様、レポートを `.ai-agent/tmp/<YYYYMMDD>-bash-allowlist/report.md` に書き出す。画面には:
+
+- レポートパス
+- 推薦パターン TOP 50（readonly / write / unknown の 3 グループに分けて、頻度 + 代表例 1 行）
+
+### スキル description
+
+“Use when …” トリガを含めた 1〜2 文。agent-coach の description トーンに揃える。
+
+## 完了条件
+
+- [x] `plugins/agent-coach/skills/recommend-bash-allowlist/SKILL.md` が存在する
+- [x] YAML フロントマターが `scripts/validate-skills.py` を pass する（`Checked 20 file(s): 0 error(s)`）
+- [x] `description` に "Use when ..." 形式のトリガ条件が含まれる
+- [x] `.ai-agent/structure.md` に新スキルディレクトリが反映されている
+- [ ] PR が作成されている
+
+## 作業ログ
+
+- 2026-05-05: トリアージ実施。要件明確・1 ブランチ・1 PR 規模のため `/autodev-start-new-task` のまま続行と判断
+- 2026-05-05: transcript の `type: permission-mode` レコードでモード区間を判定できることを確認
+- 2026-05-05: ユーザー方針確認（TOP 50 / readonly-write 判別可能な prefix 粒度 / bypassPermissions も対象）
+- 2026-05-05: ブランチ `feature/add-bash-allowlist-recommender-skill` 作成
+- 2026-05-05: `plugins/agent-coach/skills/recommend-bash-allowlist/SKILL.md` 作成。サブコマンド体系ツールの深さ表と readonly/write キーワード分類を内包
+- 2026-05-05: `.ai-agent/structure.md` 更新
+- 2026-05-05: `scripts/validate-skills.py` 実行 → 0 errors
+- 2026-05-05: `.claude/skills/recommend-bash-allowlist/skill.md` を `plugins/agent-coach/skills/recommend-bash-allowlist/SKILL.md` への相対 symlink として作成（本リポジトリ自体でも利用可能に）。structure.md も追記

--- a/.ai-agent/tasks/20260505-add-context-rot-detector-skill/README.md
+++ b/.ai-agent/tasks/20260505-add-context-rot-detector-skill/README.md
@@ -1,0 +1,150 @@
+# コンテキストロット検出スキルの追加
+
+## 目的・ゴール
+
+`plugins/agent-coach/` プラグインに、ユーザーの transcript を分析して**コンテキストロット**のシグナルを検出し、具体的な改善方法（断点・Plan 化・Subagent 委譲・MEMORY.md 移行・Compact Instructions）を提案するスキルを追加する。
+
+既存 `agent-coach` スキルは 6 観点を横断する「総合健康診断」だが、観点 4（コンテキストロット）はサマリ提示にとどまる。本スキルは観点 4 を**深掘り専用**としてフォーカスし、以下を提供する:
+
+- セッション別タイムラインで「いつ rot が始まったか」を特定
+- /clear・/compact・Plan モード移行・Subagent 委譲の**具体的な断点候補**
+- 繰り返し参照される情報の **MEMORY.md 化候補**
+- 長期セッションを支える **CLAUDE.md Compact Instructions** の雛形
+
+## 実装方針
+
+### スキル配置
+
+- ディレクトリ: `plugins/agent-coach/skills/detect-context-rot/`
+- 本体: `SKILL.md`
+- agent-coach プラグインに同居（`recommend-bash-allowlist` と並ぶ「特化型分析スキル」）
+- 既存 agent-coach の観点 4 はそのまま残し、本スキルへのリンクを SKILL.md と handbook に追記して相互参照
+
+### スキル名と description
+
+- 名前: `detect-context-rot`
+- description (英語、Use when ... トリガ含む):
+  > "Analyze recent Claude Code transcripts to detect context rot signals (turn count growth, repeated reads, fading initial instructions, bloated tool results, cache miss patterns) and suggest concrete remediation: where to /clear, when to switch to Plan mode, which investigations to delegate to subagents, what to migrate into MEMORY.md, and which CLAUDE.md Compact Instructions to add. Use when sessions feel unfocused, the model forgets earlier context, you want to diagnose long sessions, or harvest repeated patterns into structured memory."
+
+### 分析ロジック（SKILL.md に記述）
+
+1. **対象セッション特定**: agent-coach / recommend-bash-allowlist と同じ規約（cwd → `~/.claude/projects/<encoded-cwd>/` 配下、最新 N セッション、実行中セッションは除外）。本スキルは長期/重い rot シグナルを見るので**デフォルトで最新 5〜10 セッション**を推奨
+
+2. **シグナル抽出（セッション別）**:
+   - **量的シグナル**: ターン数、累積 input/output/cache_*_tokens、ターン間の mtime gap、tool_result サイズの累積分布
+   - **反復シグナル**: 同一ファイルの再 Read、同一引数の Bash 反復、同じツール（Grep/Glob/Read）の似た呼び出し
+   - **指示忘却シグナル**: CLAUDE.md / 初期 system reminder / 初期ユーザー指示で示されたルールに後半で違反した箇所
+   - **巨大ツール出力シグナル**: > 5000 文字の tool_result、> 50KB の Read、> 100 行の Bash 出力
+   - **断点欠落シグナル**: 50 ターン以上 /clear なし、Plan モードに入らず長期実装、Subagent を呼ばずに重い調査
+
+3. **rot 開始ターン推定**:
+   - 累積 cache_creation_input_tokens の屈曲点（前半 30 ターンの平均×2 を超えたターン）
+   - 同じファイル/コマンドが 2 回以上反復し始めたターン
+   - 上記 2 つのうち**早い方**を「rot 始点候補」とする
+   - 「ここで /clear すべきだった」候補ターンとして報告
+
+4. **クロスセッション傾向**:
+   - 平均ターン数、平均トークン、rot 始点までの平均ターン数
+   - 同じファイル/トピックを複数セッションで繰り返し Read している → MEMORY.md 候補
+   - 同じユーザー指示が複数セッションで欠落している → CLAUDE.md / memory ファイル化候補
+
+5. **改善提案カテゴリ**（finding を 5 つのアクションに mapping）:
+   - **A. 断点（/clear・/compact）**: 「セッション X のターン N 以降は別タスク。/clear 推奨」
+   - **B. Plan モード化**: 「長期実装タスクは最初に Plan で方針確定 → 実行ターンを短く」候補ターン提示
+   - **C. Subagent 委譲**: 「ターン N の重い調査は Agent(subagent_type=Explore) 候補」
+   - **D. MEMORY.md 移行**: 「ファイル X / コマンド Y が n セッションで反復 → memory 化候補」
+   - **E. CLAUDE.md Compact Instructions**: 「compaction 時に失われやすい項目（プロジェクト用語・命名規則）」雛形を提示
+
+### 出力形式
+
+レポートは画面に直接ダンプせず、ファイルに書き出す:
+
+1. 出力ディレクトリ: `.ai-agent/tmp/<YYYYMMDD>-context-rot/`（cwd 基準）
+2. レポート本文: `<出力ディレクトリ>/report.md`
+3. 画面には以下のみ表示:
+   - レポートファイルパス
+   - セッション別 rot 始点候補（最大 5 件）
+   - 推奨アクション TOP3（A〜E から効果の高い順）
+
+#### レポート構造
+
+```markdown
+# Context Rot 検出レポート
+
+対象: <セッション一覧と期間>
+
+## TL;DR
+- <セッション数> セッション中 <K> セッションで rot 始点候補を検出
+- 主因: <反復 Read / 巨大 tool 出力 / 断点欠落 など>
+- 推奨アクション TOP3 は末尾
+
+## セッション別タイムライン
+### <session-id> (<turns> turns, <tokens> tokens)
+- ターン 1〜N: 健全（<指標>）
+- ターン N+1: rot 始点候補（<シグナル>）
+- ターン N+1〜M: <反復した行動>
+- 推奨断点: ターン X / Plan 移行: ターン Y / Subagent: ターン Z
+
+## クロスセッション傾向
+- <ファイル/コマンド/トピック> を <n> セッションで反復参照 → memory 化候補
+
+## 改善提案
+
+### A. 断点（/clear・/compact）
+| セッション | 推奨ターン | 根拠 |
+| --- | --- | --- |
+
+### B. Plan モード化
+...
+
+### C. Subagent 委譲
+...
+
+### D. MEMORY.md 移行候補
+- <ファイル X>: <理由>。雛形 →
+  ```markdown
+  ---
+  name: <name>
+  description: <one-line>
+  type: reference
+  ---
+  ```
+
+### E. CLAUDE.md Compact Instructions
+suggested addition:
+```markdown
+## Compact Instructions
+- 保持: <項目>
+- 削除: <項目>
+```
+
+## 統計サマリ
+- セッション数 / ターン総数 / トークン総計 / 検出件数
+
+## 誤検出の可能性
+- 長い設計議論セッションは rot ではない場合あり（指標を併せて確認）
+
+## 推奨アクション TOP3
+1. ...
+```
+
+## 完了条件
+
+- [x] `plugins/agent-coach/skills/detect-context-rot/SKILL.md` が存在する
+- [x] YAML フロントマターが `scripts/validate-skills.py` を pass する（`Checked 21 file(s): 0 error(s)`）
+- [x] `description` に "Use when ..." 形式のトリガ条件が含まれる
+- [x] 既存 agent-coach の観点 4 セクションに本スキルへの相互参照を追記（SKILL.md 本体 + reference/handbook.md）
+- [x] `.ai-agent/structure.md` に新スキルディレクトリが反映されている
+- [x] `.claude/skills/detect-context-rot/skill.md` を本体への symlink として作成
+- [ ] PR が作成されている
+
+## 作業ログ
+
+- 2026-05-05: トリアージ実施。要件明確・1 PR 規模のため `/autodev-start-new-task` のまま続行と判断
+- 2026-05-05: ユーザー方針確認（agent-coach 観点 4 をフォーカスした独立スキルとして並存 / 同ブランチで継続）
+- 2026-05-05: bash-allowlist 作業を別コミット (`84fbf7b`) として整理し、context-rot タスクを開始
+- 2026-05-05: `plugins/agent-coach/skills/detect-context-rot/SKILL.md` 作成。rot 始点推定アルゴリズム（トークン屈曲点 / 反復出現点 / 巨大出力連発点の最早採用）と A〜E（断点 / Plan / Subagent / MEMORY.md / Compact Instructions）の改善カテゴリを内包
+- 2026-05-05: 既存 agent-coach `SKILL.md` 観点 4 と `reference/handbook.md` 観点 4 に detect-context-rot への案内を追記
+- 2026-05-05: `.ai-agent/structure.md` 更新（plugins ツリー + .claude/skills 両方）
+- 2026-05-05: `.claude/skills/detect-context-rot/skill.md` を `plugins/agent-coach/skills/detect-context-rot/SKILL.md` への相対 symlink として作成
+- 2026-05-05: `scripts/validate-skills.py` 実行 → 0 errors（21 ファイル検査）

--- a/.claude/skills/detect-context-rot/skill.md
+++ b/.claude/skills/detect-context-rot/skill.md
@@ -1,0 +1,1 @@
+../../../plugins/agent-coach/skills/detect-context-rot/SKILL.md

--- a/.claude/skills/recommend-bash-allowlist/skill.md
+++ b/.claude/skills/recommend-bash-allowlist/skill.md
@@ -1,0 +1,1 @@
+../../../plugins/agent-coach/skills/recommend-bash-allowlist/SKILL.md

--- a/plugins/agent-coach/skills/agent-coach/SKILL.md
+++ b/plugins/agent-coach/skills/agent-coach/SKILL.md
@@ -166,6 +166,8 @@ allowed-tools: Bash, Read, Write, Glob, Grep, WebFetch
 
 量的目安と Compact Instructions サンプル → [reference/handbook.md#観点-4-コンテキストロット](reference/handbook.md#観点-4-コンテキストロット)
 
+本観点で finding が複数出たり、クロスセッションでの傾向確認・MEMORY.md 移行候補の抽出までしたい場合は、深掘り専用の `detect-context-rot` スキル（同プラグイン同梱）を案内する。
+
 #### 観点 5: スキル未活用
 
 手順:

--- a/plugins/agent-coach/skills/agent-coach/reference/handbook.md
+++ b/plugins/agent-coach/skills/agent-coach/reference/handbook.md
@@ -157,6 +157,10 @@ CLAUDE.md は advisory、Hook は deterministic。文面改善で繰り返し違
 - Drop debug log dumps
 ```
 
+### 深掘りツール
+
+`detect-context-rot` スキル（同プラグイン同梱）を使うと、セッション別 rot 始点ターンの推定、クロスセッション反復ファイル/コマンドの抽出、A〜E（断点 / Plan / Subagent / MEMORY.md / Compact Instructions）への分類までを自動化できる。観点 4 で複数 finding が出るプロジェクトでは案内する。
+
 ---
 
 ## 観点 5: スキル description 改善

--- a/plugins/agent-coach/skills/detect-context-rot/SKILL.md
+++ b/plugins/agent-coach/skills/detect-context-rot/SKILL.md
@@ -1,0 +1,364 @@
+---
+description: Analyze recent Claude Code transcripts to detect context rot signals (turn count growth, repeated reads, fading initial instructions, bloated tool results, cache miss patterns) and suggest concrete remediation -- where to /clear, when to switch to Plan mode, which investigations to delegate to subagents, what to migrate into MEMORY.md, and which CLAUDE.md Compact Instructions to add. Use when sessions feel unfocused, the model forgets earlier context, you want to diagnose long sessions, or harvest repeated patterns into structured memory.
+allowed-tools: Bash, Read, Write, Glob, Grep
+---
+
+# detect-context-rot
+
+## 概要
+
+ユーザーの transcript JSONL を分析し、**コンテキストロット**（履歴肥大による応答品質の劣化）を検出する特化スキル。`agent-coach` の観点 4 が「サマリ提示」にとどまるのに対し、本スキルは:
+
+1. セッション別タイムラインで **rot 始点ターン候補**を推定
+2. クロスセッションで反復される情報を **MEMORY.md / CLAUDE.md 化候補**として抽出
+3. 改善を 5 カテゴリ（**A. 断点 / B. Plan 化 / C. Subagent 委譲 / D. MEMORY 移行 / E. Compact Instructions**）に分類した上で具体的な雛形を提示
+
+`agent-coach` の総合健康診断で「コンテキストロットが主因らしい」とわかった後の**深掘り**として呼び出すのが想定ユースケース。単独でも動く。
+
+## 前提条件
+
+- macOS / Linux 環境（transcript パスは `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`）
+- 分析対象セッションが少なくとも 3 件存在すること（クロスセッション傾向のため。1〜2 件しかない場合は単一セッション分析にフォールバック）
+- （任意）プロジェクトの `CLAUDE.md`・`~/.claude/CLAUDE.md`・既存 `MEMORY.md` が読めると、移行候補の重複判定がより正確
+
+## 手順
+
+### 1. 分析対象セッションの決定
+
+- **対象プロジェクト**: 現在の cwd に対応する `~/.claude/projects/<encoded-cwd>/`。`Glob` または `ls ~/.claude/projects/ | grep <repo-basename>` で実在ディレクトリを特定する
+- **対象セッション**: そのディレクトリ配下の `*.jsonl` を mtime 降順で**最新 5〜10 セッション**（rot は単一セッションでも見えるが、クロスセッション傾向を出すには複数必要）
+- **除外**: 実行中セッション（mtime 最新の 1 件）。ユーザーが明示指定した場合は除外しない
+
+候補セッション一覧（ファイル名 / mtime / サイズ / 概算ターン数）を簡潔に提示してから処理に進む。
+
+### 2. JSONL の構造把握（rot 検出に使うフィールド）
+
+| 場所 | 用途 |
+| --- | --- |
+| `type == "user"` | ユーザー指示の取得（初期指示・修正指示） |
+| `type == "assistant"` | 応答 + `message.usage`（トークン）+ `message.content[]` の `tool_use` |
+| `type == "system"` | system reminder。CLAUDE.md / 利用可能スキル一覧の取得 |
+| `assistant.message.usage.cache_creation_input_tokens` | cache miss 量。蓄積で rot を見る |
+| `assistant.message.usage.cache_read_input_tokens` | cache hit。減ると劣化シグナル |
+| `tool_use` の `name` / `input` | 反復シグナルの識別（同一引数で同ツール再呼び出し） |
+| 直後の `user.tool_result.content` 文字数 | 巨大ツール出力の判定 |
+| 各レコードの timestamp（または記録順） | ターン番号 N の決定 |
+
+**1 ファイル全文 Read は避ける**。1MB 超のファイルは `Bash` で `wc -l` → 必要箇所のみ `sed -n` または `python3` で集計する。実装ヒントは末尾参照。
+
+### 3. シグナル抽出（セッション別）
+
+各シグナルは独立して計算し、後段の **rot 始点推定** で統合する。
+
+#### 3.1 量的シグナル（ターン単位の系列）
+
+各 assistant ターン N に対して以下を記録:
+
+- `usage.cache_creation_input_tokens`（累積も）
+- `usage.cache_read_input_tokens`（累積も）
+- `usage.input_tokens` / `output_tokens`
+- 直近 `tool_result` の文字数合計（このターンに紐づく tool_use への返答）
+
+#### 3.2 反復シグナル
+
+- **同一ファイル再 Read**: `Read` の `input.file_path` が同セッション内で 2 回以上、かつ `offset/limit` が同一または重複 → カウント
+- **同一 Bash 反復**: `Bash` の `input.command` が完全一致 or 正規化（`cd ... &&` 剥がし、空白圧縮）後一致で 2 回以上 → カウント
+- **似た Grep/Glob 反復**: 同一 `pattern` または同一 `glob` で 3 回以上 → カウント
+
+各反復について「初回ターン N1, 再出現 N2, N3, ...」を記録。
+
+#### 3.3 巨大ツール出力シグナル
+
+- `tool_result` 単体の文字数 > 5000
+- `Read` で `limit` 指定なしの全文取得が大きいファイルを返した（行数 > 500）
+- `Bash` 出力が 100 行 / 5000 文字を超える
+
+各イベントのターン番号と推定文字数を記録。
+
+#### 3.4 指示忘却シグナル
+
+- セッション冒頭の `system` reminder / CLAUDE.md / 最初のユーザー指示で示されたルール（"必ず X する", "Y してはいけない", "出力は Z 形式"）を抽出
+- 後半（rot 始点候補以降）でこれらに違反している assistant 行動があれば記録
+- 例: 「コミットは指示時のみ」とあるのに勝手に commit、「テスト不要」とあるのにテストを書き始める、等
+
+#### 3.5 断点欠落シグナル
+
+- セッション全体のターン数が 50 を超え、かつ `/clear` を示す user メッセージや明示的な `/compact` 痕跡が無い
+- 累積トークンが 200K を超えたまま継続している
+- Plan モードに入った形跡が無い長期実装（assistant が `ExitPlanMode` を呼ばずに 30 ターン以上連続実装）
+- 重い調査ターン（巨大 tool_result 連発）が `Agent(subagent_type=Explore)` を呼ばず main で行われた
+
+### 4. rot 始点ターン推定
+
+セッションごとに以下 3 候補のうち**最も早い**ターンを「rot 始点候補」とする。3 候補すべてが揃わないこともあるので、揃った候補のみで判定する。
+
+1. **トークン屈曲点**: 累積 `cache_creation_input_tokens` の傾きが、セッション前半 30 ターン（ターン数が少なければ前半 1/3）の平均増加率の **2 倍**を初めて超えたターン
+2. **反復出現点**: 反復シグナル（3.2）で「再出現 N2」が初めて検出されたターン
+3. **巨大出力連発点**: 巨大ツール出力シグナル（3.3）が **3 ターン以内に 2 回以上**続けて発生し始めたターン
+
+候補が複数あれば最も早いターンを採用。**始点後**の挙動として「指示忘却（3.4）」「断点欠落（3.5）」が現れたらレポートに併記する。
+
+**注意**: 始点はあくまで推定。長い設計議論セッション、データ集計セッション等は rot ではない場合がある。レポートでは「可能性」のトーンを基本とし、誤検出条件を併記する（手順 7）。
+
+### 5. クロスセッション傾向の抽出
+
+複数セッションを横断して以下を集計:
+
+- **反復ファイル**: 全セッション通算で 5 回以上 Read されているファイル → MEMORY.md / reference 化候補
+- **反復コマンド**: 全セッション通算で 5 回以上 Bash 実行されているコマンド（or その引数なしバージョン）→ skill 化候補 / hook 化候補
+- **反復指示違反**: 同じルール違反が複数セッションで起きている → CLAUDE.md / memory ルール化が必要 / 既存ルールの言い回し改善
+- **平均 rot 始点**: 何ターン目あたりで rot に入りやすいか
+- **平均ターン数 / 平均トークン**: rot に入る前に切るべき目安
+
+### 6. 改善提案カテゴリへのマッピング
+
+検出した finding を以下 5 カテゴリに振り分ける。1 つの finding が複数カテゴリに該当することもある（その場合は最も即効性のあるカテゴリに main で配置し、他は補足参照）。
+
+#### A. 断点（/clear・/compact）
+
+- 適用条件: 単一セッションで rot 始点後に**異なるトピック**へ遷移している、または始点後 20 ターン以上経過
+- 出力: 「セッション X のターン N 以降は /clear 推奨」+ 根拠
+- /compact を選ぶ目安: 後段でも前半成果物（テスト結果・修正ファイル一覧）が必要な場合は `/compact <保持指示>`
+
+#### B. Plan モード化
+
+- 適用条件: 30 ターン以上の連続実装で、初期に Plan 確定がなく途中で方針修正が複数回入った場合
+- 出力: 「次回類似タスクは ExitPlanMode 後に実装開始すべき」候補ターン提示
+
+#### C. Subagent 委譲
+
+- 適用条件: 巨大ツール出力（3.3）が 3 件以上 main コンテキストに入っている、または重い調査が複数ターンに分散
+- 出力: 「ターン N の調査は Agent(subagent_type=Explore) 候補」+ 推奨プロンプト雛形 1 行
+
+#### D. MEMORY.md 移行候補
+
+- 適用条件: クロスセッション反復ファイル / 反復コマンド / 反復ユーザー説明
+- 出力: memory ファイル雛形（type は user / project / reference / feedback の中から内容で判定）
+
+```markdown
+---
+name: <kebab-case-name>
+description: <one-line>
+type: <user | project | reference | feedback>
+---
+
+<本文>
+```
+
+判定例:
+- ファイル X を毎回 Read → `reference` 型 + ファイルの位置とその役割を記録
+- ユーザーが毎回同じ前提（「自分は Go 専門で React は初めて」）を説明 → `user` 型
+- 毎回同じ修正指示が来る → `feedback` 型（**Why:** / **How to apply:** を含める）
+
+#### E. CLAUDE.md Compact Instructions
+
+- 適用条件: compaction で消えていそうな項目が rot 後半で再質問されている、または long session の運用が常態化している
+- 出力: CLAUDE.md 末尾に追加する雛形
+
+```markdown
+## Compact Instructions
+- 保持: 修正済みファイル一覧、実行したテストコマンドと結果、ユーザーの最新指示
+- 削除: ツール出力の生ダンプ、デバッグ用ログ、繰り返し読んだファイルの全文
+```
+
+実プロジェクトの状況に合わせて「保持」「削除」項目をカスタマイズする。
+
+### 7. レポート生成
+
+レポートは画面に直接ダンプせず、ファイルに書き出す。
+
+1. 出力ディレクトリ: **`.ai-agent/tmp/<YYYYMMDD>-context-rot/`**（cwd 基準）。存在しなければ `mkdir -p`
+2. レポート本文: `<出力ディレクトリ>/report.md` を `Write` で書き出す
+3. 画面には以下のみ表示:
+   - レポートファイルパス
+   - セッション別 rot 始点候補（最大 5 セッション分、ターン番号と主因シグナル）
+   - 推奨アクション TOP3（A〜E から効果順）
+
+#### レポート構造（ファイル本文）
+
+````markdown
+# Context Rot 検出レポート
+
+対象: <セッション一覧 / 期間>
+分析範囲: 最新 N セッション (<earliest> 〜 <latest>)
+
+## TL;DR
+
+- <K> / <N> セッションで rot 始点候補を検出
+- 主因: <反復 Read / 巨大ツール出力 / 断点欠落 / 指示忘却 など上位 2 つ>
+- クロスセッション傾向: <反復ファイル M 件 / 反復コマンド L 件>
+- → 推奨アクション TOP3 は末尾
+
+---
+
+## セッション別タイムライン
+
+### `<session-id>` (<turns> turns, <input/output/cache> tokens, mode: <auto|default|...>)
+
+| 範囲 | フェーズ | 主なシグナル |
+| --- | --- | --- |
+| ターン 1〜N1 | 健全 | <代表的な行動> |
+| ターン N1 | rot 始点候補 | <トークン屈曲 / 反復 / 巨大出力> |
+| ターン N1〜N2 | 兆候 | <反復項目を 1〜2 行> |
+| ターン N2〜end | 顕在化 | <指示忘却 / 検証なし完了 など> |
+
+推奨断点: ターン X (/clear) ／ Plan 移行: ターン Y ／ Subagent: ターン Z
+
+(セッション数だけ繰り返し。最大 5 セッション。それ以上は「その他のセッション」に圧縮)
+
+---
+
+## クロスセッション傾向
+
+### 反復ファイル（MEMORY.md 化候補）
+| ファイル | 通算 Read | 主な用途 | 移行型 |
+| --- | ---: | --- | --- |
+| `<path>` | 12 | <要約> | reference |
+
+### 反復コマンド
+| コマンド | 通算実行 | 用途 | 提案 |
+| --- | ---: | --- | --- |
+| `<cmd>` | 7 | <要約> | hook 化 / skill 化 / そのまま |
+
+### 反復指示違反
+- ルール「<...>」が <n> セッションで違反 → CLAUDE.md 言い回し改善 / 専用 memory ファイル化
+
+### 全体指標
+- 平均ターン数: <X>
+- 平均トークン総計: <Y>
+- 平均 rot 始点ターン: <Z>（rot 検出セッションのみ）
+
+---
+
+## 改善提案
+
+### A. 断点（/clear・/compact）
+| セッション | 推奨ターン | 理由 |
+| --- | --- | --- |
+
+### B. Plan モード化
+| セッション | 推奨ターン | 理由 |
+| --- | --- | --- |
+
+### C. Subagent 委譲
+| セッション | ターン | 推奨呼び出し |
+| --- | --- | --- |
+| <id> | N | `Agent(subagent_type=Explore, prompt="...")` |
+
+### D. MEMORY.md 移行候補
+
+#### 候補 1: <name>
+雛形:
+```markdown
+---
+name: <name>
+description: <one-line>
+type: <type>
+---
+
+<本文>
+```
+根拠: <反復回数>, <代表セッション>
+
+(候補ごとに繰り返し)
+
+### E. CLAUDE.md Compact Instructions
+
+```markdown
+## Compact Instructions
+- 保持: <カスタマイズした項目>
+- 削除: <カスタマイズした項目>
+```
+
+根拠: <どのセッションで何が消えたか>
+
+---
+
+## 統計サマリ
+- セッション数: N
+- ターン総数: <合計>
+- トークン総計: input <I> / output <O> / cache_creation <C> / cache_read <R>
+- rot 検出件数: <K> / <N> セッション
+- finding 件数: 反復 <a> / 巨大出力 <b> / 指示忘却 <c> / 断点欠落 <d>
+
+## 誤検出の可能性
+- 長い設計議論セッションは rot ではない場合あり（`/context` で実使用率を確認推奨）
+- 巨大ツール出力でもユーザー意図の調査タスクなら問題ない
+- 反復 Read でも頻繁に変わるファイルなら正常
+
+## 推奨アクション TOP3
+1. **<アクション>** — <1 行の why と how>
+2. **<アクション>** — <1 行の why と how>
+3. **<アクション>** — <1 行の why と how>
+````
+
+#### TOP3 の優先度
+
+| Tier | 内容 |
+| --- | --- |
+| Tier 1（必ず TOP3） | rot が 3 セッション以上で再現 / 指示忘却が複数セッション / 平均ターン数 80 超 |
+| Tier 2（影響大なら TOP3） | 単一セッション rot で 30 ターン以上の被害 / 巨大ツール出力 5 件以上 / 反復 Read 5 回以上の単一ファイル |
+| Tier 3（運用改善） | 軽微な反復コマンド / cache miss 単発 / 単発の指示忘却 |
+
+判断基準: **複数セッションにわたって効果が継続するもの**を上に。Compact Instructions（E）と MEMORY.md 移行（D）は中長期で効くので Tier 1 に上がりやすい。
+
+### 8. 実装ヒント
+
+`Bash` で `python3` ヒアドキュメントを使い一気に集計するのが効率的。骨格例:
+
+```python
+import json, glob, os, re
+from collections import Counter, defaultdict
+
+SESSIONS = sorted(
+    glob.glob(os.path.expanduser("~/.claude/projects/<encoded-cwd>/*.jsonl")),
+    key=os.path.getmtime, reverse=True
+)[1:11]  # 実行中除外して 10 件
+
+def per_turn_metrics(path):
+    cache_creation = []
+    tool_result_sizes = []
+    file_reads = Counter()
+    bash_cmds = Counter()
+    for line in open(path):
+        rec = json.loads(line)
+        if rec.get("type") == "assistant":
+            usage = rec.get("message", {}).get("usage", {})
+            cache_creation.append(usage.get("cache_creation_input_tokens", 0))
+            for block in rec.get("message", {}).get("content", []):
+                if block.get("type") == "tool_use":
+                    if block["name"] == "Read":
+                        file_reads[block["input"].get("file_path")] += 1
+                    elif block["name"] == "Bash":
+                        bash_cmds[block["input"].get("command", "").strip()] += 1
+        elif rec.get("type") == "user":
+            for block in rec.get("message", {}).get("content", []) if isinstance(rec.get("message", {}).get("content"), list) else []:
+                if block.get("type") == "tool_result":
+                    content = block.get("content", "")
+                    size = len(content) if isinstance(content, str) else sum(len(p.get("text", "")) for p in content if isinstance(p, dict))
+                    tool_result_sizes.append(size)
+    return cache_creation, tool_result_sizes, file_reads, bash_cmds
+
+def rot_inflection_turn(cache_series):
+    """累積系列の傾きが前半平均の 2 倍を超えた最初のターン。"""
+    if len(cache_series) < 10:
+        return None
+    half = len(cache_series) // 3
+    early_rate = sum(cache_series[:half]) / max(half, 1)
+    for i in range(half, len(cache_series)):
+        if cache_series[i] > early_rate * 2:
+            return i
+    return None
+```
+
+完全実装は不要 — Claude が transcript を読み取り上記指標を集計できれば良い。集計が複雑になりすぎたら**1 ファイル / 1 セッションだけ手で読み込み**、定性的に finding を作っても十分価値がある（このスキルのゴールは「ユーザーが次の行動を選べる」こと）。
+
+## 注意事項
+
+- **transcript には機密情報が含まれる可能性がある**。レポート作成時、コマンド例やファイルパスにシークレット類が混入していないか軽くチェックし、疑わしければマスクする（agent-coach の観点 0 と同じ方針）
+- **自分自身のセッションを分析しないこと**（ユーザー明示対象時を除く）。mtime 最新の jsonl を実行中セッションとみなして除外
+- **巨大 JSONL の全文 Read を避ける**。1 ファイル 1MB を超える場合は `python3` での集計を併用
+- **rot 始点はあくまで推定**。閾値ヒューリスティックなので「可能性」のトーンを基本に、誤検出条件を必ず併記する
+- **agent-coach との関係**: 総合健康診断で「コンテキストロットが主因らしい」とわかった後の深掘りツール。観点 4 の TL;DR と矛盾しないこと（同じセッションを見ているはずなので、検出傾向は一致する想定）
+- **改善提案は具体的に**。「もう少し短く運用してください」ではなく「ターン N で /clear、Plan 移行はターン M、MEMORY.md 雛形は以下」まで提示する
+- **レポートはファイルに書き出し**、画面には TL;DR + TOP3 + パスのみ表示する

--- a/plugins/agent-coach/skills/recommend-bash-allowlist/SKILL.md
+++ b/plugins/agent-coach/skills/recommend-bash-allowlist/SKILL.md
@@ -1,0 +1,265 @@
+---
+description: Analyze recent Claude Code transcripts to find Bash commands that ran in auto / bypassPermissions mode but are not in permissions.allow, and recommend allowlist patterns grouped by readonly / write. Use when the user wants to harvest auto-mode usage into a curated allowlist, audit which commands run without prompts, or migrate from auto mode to default / acceptEdits without losing convenience.
+allowed-tools: Bash, Read, Write, Glob, Grep
+---
+
+# recommend-bash-allowlist
+
+## 概要
+
+ユーザーの transcript JSONL を分析し、`auto` または `bypassPermissions` モード下で実行された `Bash` コマンドのうち、現在の `permissions.allow` にマッチしないものを抽出する。前方一致パターン（`Bash(<prefix>:*)` 形式）に集約し、readonly / write / unknown の 3 グループに分類して TOP 50 を提示する。ユーザーは結果から安全なものを `permissions.allow` に追加することで、緩いモードを抜けても同等の使用感を維持できる。
+
+## 前提条件
+
+- macOS / Linux 環境（transcript パスは `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`）
+- 分析対象セッションが少なくとも 1 件存在し、そのうち最低 1 件が `auto` または `bypassPermissions` モードでの実行を含むこと
+- `~/.claude/settings.json` または `<repo>/.claude/settings*.json` の少なくとも片方が読める（無くてもエラーにはせず、空 allowlist 扱いで進める）
+
+## 手順
+
+### 1. 分析対象セッションの決定
+
+- **対象プロジェクト**: 現在の cwd に対応する `~/.claude/projects/<encoded-cwd>/`。`Glob` または `ls ~/.claude/projects/ | grep <repo-basename>` で実在ディレクトリを特定する
+- **対象セッション**: そのディレクトリ配下の `*.jsonl` を mtime 降順で最新 5〜10 セッション
+- **除外**: 実行中セッション（mtime 最新の 1 件）。ユーザーが明示指定した場合は除外しない
+- **件数の調整**: ユーザーから指定があれば従う
+
+候補セッション一覧（ファイル名 / mtime / サイズ）を簡潔に提示してから処理に進む。
+
+### 2. JSONL の構造把握
+
+各行が独立した JSON オブジェクト。本スキルで使う主なフィールド:
+
+| 場所 | 内容 |
+| --- | --- |
+| `type == "permission-mode"` のレコード | そのターン以降の `permissionMode` を切替（`auto`, `default`, `plan`, `acceptEdits`, `bypassPermissions` 等） |
+| `type == "assistant"` の `message.content[]` 内の `tool_use` ブロック（`name == "Bash"`） | Bash 呼び出し本体。`input.command` に実コマンド |
+| `cwd`, `gitBranch`, `sessionId` | 文脈用 |
+
+**permissionMode 区間の構築**:
+
+1. ファイル先頭からシーケンシャルに走査
+2. `type == "permission-mode"` を見つけたら現在モードを更新
+3. それ以降の `tool_use` レコードに「現在のモード」を割り当てる
+4. ファイル冒頭にモードレコードが無い場合は `default` 扱い
+
+### 3. 対象 Bash コマンドの抽出
+
+各 `tool_use` (Bash) について:
+
+- 現在の permissionMode が `auto` または `bypassPermissions` のもののみ採用
+- `input.command` を取得
+- `cd /path && actual_cmd` のような連結は **`actual_cmd` 部分** を解析対象とする（`cd ... && `、`export X=Y && ` などの prefix は剥がす）
+- `;`, `&&`, `||`, `|` で連結された複数コマンドは **左から順に各々を解析対象**にする（ただし複雑な引用や heredoc が絡む場合は最初のコマンドのみで妥協してよい）
+
+巨大セッションは `python3 -c "..."` で集約することを推奨。1 ファイル全文 Read は避ける。
+
+### 4. 現行 allowlist の取得
+
+以下を順に読み、`permissions.allow` を結合:
+
+1. `~/.claude/settings.json`
+2. `<repo>/.claude/settings.json`
+3. `<repo>/.claude/settings.local.json`
+
+各エントリは `Bash(<pattern>)` または `Bash(<pattern>:*)` 形式。比較用に以下に正規化:
+
+- `Bash(git log:*)` → prefix `git log`、suffix glob あり
+- `Bash(npm install)` → prefix `npm install`、完全一致のみ
+- `Bash(<other-tool>...)` → 本スキルでは Bash 以外は無視
+
+### 5. prefix の抽出（readonly/write 判別可能な粒度）
+
+各コマンドから prefix を抽出する。深さは「readonly か write かを人間が判断できる単位」を目安に決める。
+
+#### 抽出ルール
+
+1. コマンドを空白でトークナイズ
+2. 先頭トークンを取得
+3. 先頭トークンが下表の「サブコマンド体系ツール」に該当する場合、指定深さまでトークンを連結
+4. それ以外は先頭トークンのみ
+5. オプションフラグ（`-`, `--` で始まるトークン）は中間に挟まっても無視せずスキップする（例: `git --no-pager log` → `git log`）。ただし `git rebase --continue` のように **動作を決定するフラグ** はそのまま含める（heuristic: 終端のフラグなら含める）
+
+#### サブコマンド体系ツールの深さ表
+
+| ツール | 深さ | 例 |
+| --- | --- | --- |
+| `git` | 2 | `git log`, `git push`, `git rebase --continue` |
+| `gh` | 3 | `gh pr view`, `gh issue list`, `gh run watch` |
+| `npm` | 2 | `npm install`, `npm run`, `npm test` |
+| `pnpm` / `yarn` | 2 | `pnpm add`, `yarn install` |
+| `npx` | 2 | `npx tsc`, `npx eslint` |
+| `aws` | 3 | `aws s3 ls`, `aws sts get-caller-identity` |
+| `gcloud` / `az` | 3 | `gcloud compute instances list` |
+| `kubectl` | 2 | `kubectl get`, `kubectl apply` |
+| `docker` / `podman` | 2 | `docker ps`, `docker build` |
+| `brew` / `mas` | 2 | `brew info`, `mas search` |
+| `nix` | 2 | `nix flake show`, `nix search` |
+| `cargo` / `go` / `dotnet` | 2 | `cargo build`, `go test` |
+| `terraform` / `tofu` | 2 | `terraform plan`, `terraform apply` |
+| `make` | 1 | `make` |
+| `uv` / `pip` / `poetry` | 2 | `uv pip list`, `pip show` |
+| その他のコマンド | 1 | `ls`, `cat`, `find`, `grep`, `jq`, `head` |
+
+ツール固有の慣用句（`nix-prefetch-url`, `nix-prefetch-github` 等）は単一トークンとして扱う。
+
+最終的に推薦パターンは `Bash(<prefix>:*)` 形式に整形する。
+
+### 6. readonly / write / unknown の分類
+
+prefix の **末尾の動詞トークン** を以下のキーワードリストで分類する。マッチしないものは `unknown` として扱う。誤分類があり得るので、レポート上で「この分類は heuristic」と明示する。
+
+#### readonly キーワード
+
+- 観察系: `log`, `status`, `show`, `view`, `get`, `list`, `ls`, `ll`, `head`, `tail`, `cat`, `less`, `more`, `diff`, `describe`, `inspect`, `info`, `outdated`, `audit`, `search`, `whoami`, `pwd`, `find`, `grep`, `rg`, `fd`
+- 検査系: `check`, `test`, `lint`, `validate`, `dry-run`, `--dry-run`, `--help`, `-h`, `--version`, `version`
+- git 系: `rev-parse`, `ls-files`, `ls-remote`, `ls-tree`, `merge-base`, `symbolic-ref`, `remote`（get-url 等）, `submodule`（status 等）, `blame`, `shortlog`, `cherry`, `name-rev`
+- gh 系: `pr view`, `pr list`, `pr diff`, `pr checks`, `issue view`, `issue list`, `repo view`, `release view`, `release list`, `run view`, `run list`, `run watch`, `run download`, `cache list`, `label list`, `search`
+- aws 系: `get-`, `list-`, `describe-`, `head-`（プレフィックス match）
+
+#### write キーワード
+
+- 変更系: `install`, `add`, `update`, `upgrade`, `remove`, `uninstall`, `delete`, `rm`, `mv`, `cp`, `chmod`, `chown`, `mkdir`, `rmdir`, `touch`
+- ビルド系: `build`, `compile`, `bundle`, `pack`, `publish`, `release`
+- 実行系: `exec`, `run`, `start`, `stop`, `restart`, `kill`, `apply`, `destroy`, `init`, `migrate`, `seed`
+- VCS 系: `commit`, `push`, `pull`, `fetch`, `merge`, `rebase`, `checkout`, `branch`, `tag`, `reset`, `stash`, `cherry-pick`, `revert`
+- 編集系: `format`, `fix`（lint --fix 等は write 寄り）
+
+#### 判定優先順位
+
+1. prefix 末尾トークンが write キーワードに完全一致 → write
+2. prefix 末尾トークンが readonly キーワードに完全一致 → readonly
+3. prefix 末尾トークンが `aws` の `get-`/`list-`/`describe-`/`head-` で始まる → readonly
+4. それ以外 → unknown
+
+「`gh pr view`」のように prefix 全体で意味を持つ場合は最後のトークン (`view`) を見れば良い。
+
+### 7. 集約と TOP 50 選定
+
+- 同一 prefix のコマンドを集計（出現回数 + 代表コマンド例 1〜2 件）
+- 既に `permissions.allow` でマッチするものは除外
+  - prefix がいずれかの allowlist エントリの prefix と完全一致 → 除外
+  - prefix が allowlist エントリの prefix の **下位（より長い接頭辞）** → 除外（既に親パターンで許可済み）
+  - 例: 既に `Bash(git:*)` があれば `git log` は除外。`Bash(git log:*)` があれば `git log --oneline` 由来の prefix `git log` は除外
+- 出現回数の多い順に並べ、上位 50 件を選択
+- 同数の場合は readonly を優先
+
+### 8. レポート生成
+
+レポートは画面に直接ダンプせず、ファイルに書き出す:
+
+1. 出力ディレクトリは **`.ai-agent/tmp/<YYYYMMDD>-bash-allowlist/`**（cwd 基準）。存在しなければ `mkdir -p`
+2. レポート本文を `.ai-agent/tmp/<YYYYMMDD>-bash-allowlist/report.md` として `Write`
+3. 画面には以下のみ表示する:
+   - レポートファイルのパス
+   - 各グループ件数（readonly / write / unknown）
+   - 上位 5 件のサマリ（推薦パターン + 出現回数）
+
+#### レポート構造
+
+````markdown
+# Bash allowlist 推薦レポート
+
+対象: <セッション一覧と期間>
+分析モード: auto + bypassPermissions
+現行 allowlist: ~/.claude/settings.json (N 件) + <repo>/.claude/settings.json (M 件) + <repo>/.claude/settings.local.json (K 件)
+
+## サマリ
+
+- 抽出コマンド総数: <N>
+- 既存 allowlist でカバー済み: <M>
+- 推薦候補（未カバー）: <K>
+  - readonly: <X>
+  - write: <Y>
+  - unknown: <Z>
+
+## 推薦パターン TOP 50
+
+### 🟢 readonly (<件数>)
+
+| 推薦パターン | 出現回数 | 代表コマンド例 |
+| --- | ---: | --- |
+| `Bash(git log:*)` | 42 | `git log --oneline -10` |
+| `Bash(ls:*)` | 38 | `ls -la /path/to/dir` |
+| ... | | |
+
+### 🟡 write (<件数>)
+
+| 推薦パターン | 出現回数 | 代表コマンド例 |
+| --- | ---: | --- |
+| `Bash(npm install)` | 12 | `npm install` |
+| `Bash(git commit:*)` | 8 | `git commit -m "..."` |
+| ... | | |
+
+### ⚪ unknown (<件数>)
+
+heuristic で分類できなかったもの。手動確認推奨。
+
+| 推薦パターン | 出現回数 | 代表コマンド例 |
+| --- | ---: | --- |
+
+## 反映方法
+
+`~/.claude/settings.json` に追加するなら:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(git log:*)",
+      "Bash(ls:*)"
+    ]
+  }
+}
+```
+
+プロジェクト固有なら `<repo>/.claude/settings.json` に追加する。
+
+## 注意事項
+
+- 分類は heuristic。特に unknown と write はユーザー側で安全性を確認してから追加してください
+- 引数で挙動が変わるコマンド（例: `npm run <script>` の中身次第）は完全一致のほうが安全な場合があります
+- `Bash(<cmd>:*)` 形式は引数すべてを許可する glob です。スコープを絞りたい場合はリテラル指定（`Bash(npm install)` のように `:*` なし）を検討してください
+````
+
+### 9. 実装ヒント
+
+`Bash` で `python3` ヒアドキュメントを使うと一気に集計できる。例:
+
+```python
+import json, glob, os, re
+from collections import Counter
+
+SESSIONS = sorted(glob.glob(os.path.expanduser("~/.claude/projects/<encoded-cwd>/*.jsonl")), key=os.path.getmtime, reverse=True)[1:6]
+
+TARGET_MODES = {"auto", "bypassPermissions"}
+SUBCMD_DEPTH = {
+    "git": 2, "gh": 3, "npm": 2, "pnpm": 2, "yarn": 2, "npx": 2,
+    "aws": 3, "gcloud": 3, "az": 3, "kubectl": 2, "docker": 2,
+    "brew": 2, "mas": 2, "nix": 2, "cargo": 2, "go": 2, "dotnet": 2,
+    "terraform": 2, "tofu": 2, "make": 1, "uv": 2, "pip": 2, "poetry": 2,
+}
+
+def extract_prefix(cmd: str) -> str:
+    # cd ... && の剥がし、; && || の最初の節
+    cmd = re.sub(r"^(cd|export|env)\s+\S+\s*&&\s*", "", cmd).strip()
+    head = re.split(r"\s*[;&|]\s*", cmd, maxsplit=1)[0].strip()
+    tokens = [t for t in head.split() if not (t.startswith("-") and t not in ("--continue", "--abort"))]
+    if not tokens:
+        return ""
+    base = tokens[0]
+    depth = SUBCMD_DEPTH.get(base, 1)
+    return " ".join(tokens[:depth])
+
+# ... ループ内で permission-mode を追跡しつつ tool_use Bash を集約
+```
+
+完全実装は不要 — Claude が transcript を読み取り、推薦結果を生成できれば良い。
+
+## 注意事項
+
+- **Bash 以外のツール（Read, Write, Edit など）は対象外**。本スキルはコマンド allowlist の整備に特化する
+- **連結コマンドの解析は ベストエフォート**。複雑な heredoc / シェル展開はスキップしてよい
+- **分類は heuristic**。レポート上に「heuristic である旨」「ユーザー判断必須」を明記する
+- **transcript には機密情報を含む可能性がある**。コマンド代表例にトークン的な値が混入していないか軽くチェックし、疑わしければマスクする
+- **既存 allowlist との重複判定**は前方一致まで。`Bash(git:*)` がある状態で `git log` を提案しないこと


### PR DESCRIPTION
## 目的

agent-coach プラグインの「総合健康診断」を補完する**特化型分析スキル 2 種**を追加し、ユーザの transcript / 設定状況からより具体的な改善アクションを引き出せるようにする。

## 変更概要

### 1. `recommend-bash-allowlist` スキル (commit 84fbf7b)

- auto / bypassPermissions モード下で実行された Bash コマンド実績を transcript から収集し、`.claude/settings.json` の `permissions.allow` に未掲載のものを **readonly / write** に分類して allowlist 推薦
- auto モードから default / acceptEdits に移行する際の利便性を保つための「採用候補」を提示

### 2. `detect-context-rot` スキル (commit 1385133)

- agent-coach の観点 4（コンテキストロット）を**深掘り専用**に切り出した特化スキル
- セッション別タイムラインで **rot 始点ターン候補**を推定（cache_creation 屈曲 / 反復 Read / 巨大 tool_result の 3 シグナル）
- クロスセッション傾向から **MEMORY.md / CLAUDE.md 化候補**を抽出
- 改善提案を 5 カテゴリ（A. 断点 / B. Plan 化 / C. Subagent 委譲 / D. MEMORY 移行 / E. Compact Instructions）に分類した雛形を生成
- 既存 `agent-coach` から相互参照リンクを追加（観点 4 で複数 finding が出たら本スキルを案内）

### 関連変更

- `.ai-agent/structure.md`: 新スキル 2 件を構造図に追記
- `agent-coach/SKILL.md` / `agent-coach/reference/handbook.md`: detect-context-rot への相互参照を追加
- `.claude/skills/<skill>/skill.md`: 本リポジトリ自体での試用のため symlink を配置
- `.ai-agent/tasks/20260505-add-context-rot-detector-skill/README.md`: 設計メモ

## テスト計画

- [ ] `recommend-bash-allowlist` を実行し、transcript から auto モード Bash 実績の集計と分類を確認
- [ ] `detect-context-rot` を実行し、最新 5-10 セッションから rot 始点候補とクロスセッション反復ファイル / コマンドの抽出を確認
- [ ] agent-coach 観点 4 から detect-context-rot への案内導線を確認
- [ ] 両スキルの description が想定トリガで発火することを確認
