### PR TITLE
detect-rework-and-violations: 試用評価を反映してクロスセッション反復追加指示検知を追加

### DIFF
--- a/.ai-agent/tasks/20260506-evaluate-detect-rework-and-violations/README.md
+++ b/.ai-agent/tasks/20260506-evaluate-detect-rework-and-violations/README.md
@@ -35,7 +35,7 @@
 - [x] 評価で見つかった問題点を作業ログにリストアップ
 - [x] 修正可能な問題点について SKILL.md を更新
 - [x] `python3 scripts/validate-skills.py` が通る
-- [ ] PR を作成（`/autodev-create-pr`）
+- [x] PR を作成（`/autodev-create-pr`） → https://github.com/mizunashi-mana/agent-skills/pull/16
 
 ## 作業ログ
 

--- a/.ai-agent/tasks/20260506-evaluate-detect-rework-and-violations/README.md
+++ b/.ai-agent/tasks/20260506-evaluate-detect-rework-and-violations/README.md
@@ -1,0 +1,167 @@
+# detect-rework-and-violations スキルの実使用評価と改善
+
+## 目的・ゴール
+
+`plugins/agent-coach/skills/detect-rework-and-violations/SKILL.md` を実際の transcript に対して使用し、
+
+1. SKILL.md の手順通りにレポートを生成できるか（手順の曖昧さ・不足の検出）
+2. 生成されたレポートの**指摘が正しいか**（手戻り・違反の判定が誤検出になっていないか、ルール抽出が正確か）
+3. 分析過程を知らない人が読んでも**わかりやすいか**（背景・根拠・改善案がレポート単体で理解できるか）
+4. **クロスセッションで毎回されている追加指示**（cross-session repeated additional instructions）の検知を組み込む。「追加指示の最小化」がこのスキルの目的なので、繰り返される追加指示を検出して MEMORY / CLAUDE.md / skill description 等への昇格を提案できるようにする
+
+を評価し、明らかになった問題点を SKILL.md に反映する。
+
+## 実装方針
+
+1. **試用**: 現在の `agent-skills` リポジトリの transcript（最新 5〜10 セッション）に対して SKILL.md の手順をそのまま追体験する。
+2. **評価軸**:
+   - 手順の網羅性（手戻り・違反検出のステップが詰まる箇所はないか）
+   - ルール抽出の精度（CLAUDE.md / SKILL.md / memory / system reminder からの抽出に漏れ・誤検出はないか）
+   - 検出された手戻り/違反の判定妥当性（誤検出が混入していないか、人手で読んで納得できるか）
+   - レポートの可読性（分析過程を知らない人が読んで「なぜそう判定したか / 何をすればいいか」が分かるか）
+   - **クロスセッション追加指示**の検知が今の SKILL でカバーされているか（カバーされていない場合の追加方針）
+3. **改善対象**: SKILL.md のみ（必要に応じて）。実装スクリプトを残す方針ではない（スキルはあくまで「手順書」）。
+4. **作業成果物**:
+   - `.ai-agent/tmp/20260506-rework-violations/report.md` — 試用で生成された実レポート
+   - 評価メモ（このタスクの README 作業ログ）
+   - SKILL.md 修正差分
+
+## 完了条件
+
+- [x] SKILL.md の手順通りにレポートを生成できた
+- [x] レポート内の指摘について 1 件ずつ正誤確認・誤検出の有無を評価
+- [x] 「分析過程を知らない人が読んでわかるか」観点でレポート構造を評価
+- [x] クロスセッション追加指示の検知ロジックを SKILL.md に追加
+- [x] 評価で見つかった問題点を作業ログにリストアップ
+- [x] 修正可能な問題点について SKILL.md を更新
+- [x] `python3 scripts/validate-skills.py` が通る
+- [ ] PR を作成（`/autodev-create-pr`）
+
+## 作業ログ
+
+### 2026-05-06: タスク開始
+
+- 関連ドキュメント確認: `plan.md`（Phase 2 = 品質改善・標準化フェーズ）、`structure.md`（agent-coach プラグインに分類）、過去の同種評価タスク `20260506-evaluate-recommend-bash-allowlist` を参照。
+- transcript 候補: `~/.claude/projects/-Users-mizunashi-Workspace-MyWork-agent-skills/` に 21 セッション存在。
+
+### 2026-05-06: 試用と評価
+
+試用レポート: `.ai-agent/tmp/20260506-rework-violations/report.md`
+
+データ: 最新 10 セッション（実行中 1 件除外）。違反候補 14 件 / 手戻り 0 件 / クロスセッション反復追加指示 2 種を検出。
+
+#### 検出された SKILL.md の問題点
+
+**[A] 違反検出の誤検出: slash command 由来の許可済み行動を違反扱い (Critical / 14 件中 10 件)**
+
+- 14 件中 10 件が `git commit` の誤検出。すべて `/autodev-create-pr` 経由の指示済みコミット
+- SKILL.md には「ユーザー明示指示時のみ」のルール文があるだけで、slash command 起動が「明示指示」に該当するかを判定するステップが書かれていない
+- 結果: PR 作成スキル経由のコミットを毎回違反として報告してしまう
+
+**[B] 手戻りシグナルの覆い不足: post-completion supplement パターン (Critical)**
+
+- NEG_WORDS ベースでは 0 件検出。しかし実際には「PR タイトル日本語に」「task README も含めて」のような **完了宣言寸前の追加指示** が複数セッションで発生
+- 否定・修正語を含まない建設的口調の追加指示は現行ルールから完全に漏れる
+- 4.1 に新カテゴリ「完了宣言/PR 作成/コミット直前直後の追加指示」を加える必要がある
+
+**[C] クロスセッション追加指示検知の欠落 (本タスクの主目的)**
+
+- 今のスキルには「複数セッションで繰り返される追加指示」を集約する機能が無い
+- 追加指示の最小化＝このスキルの目的、なのに「単発の手戻り / 違反」しか拾えない構造
+- 「PR タイトルを日本語に」「task README を PR に含めて」が 2 セッションずつで反復されている実例を検出できなかった
+
+**[D] guarded read (`cat ... 2>/dev/null`) の誤検出 (3 件中 2 件)**
+
+- `cat .file 2>/dev/null` は「ファイルが存在しないかもしれない」状況での妥当な代替手段（Read ツールは存在しないファイルでエラーになる）
+- 違反検出ルールの除外条件として 4.4 に明記すべき
+
+**[E] レポート可読性: 分析過程を知らない人向けの説明が薄い**
+
+- 違反/手戻りの一覧は出るが、**「なぜそれを違反/手戻りと判定したか」「反証材料はあるか」** が読み手に伝わらない
+- TL;DR の主因内訳「rot 起因」「ルール埋没」等は専門用語で初見では意味不明
+- 各事例に「判定根拠」「反証可能性」を 1〜2 行添える必要
+
+**[F] ルール抽出元の優先順位が曖昧**
+
+- 3.1 で `<repo>/CLAUDE.md`, `~/.claude/CLAUDE.md`, memory, SKILL.md 本文をフラットに列挙
+- どれを最優先で読むかの順序が無く、`~/.claude/CLAUDE.md` の system prompt 由来ルール（コミット / `--no-verify` 等）の抽出漏れリスクがある
+
+**[G] 軽微 (今回スコープ外)**
+
+- G1. 主因分類「ルール埋没」の定量化（「CLAUDE.md 中盤以降」の「中盤」とは何行目か）
+- G2. tmp スクリプトの破棄/保管ポリシー（手順 7 の `.ai-agent/tmp/` 配下に分析用スクリプトも置くか）
+
+#### 改善対象 (SKILL.md 修正で対応)
+
+優先度 1:
+
+- A: 違反検出の前段に「直前数ターンの slash command 起動と引数・テンプレートを確認」を追加（4.2 / 4.4）
+- B: 4.1 の手戻りシグナルに「post-completion supplement」を追加
+- C: 新ステップ 5.x「クロスセッション反復追加指示の集約」を追加。改善カテゴリ B / E に memory ファイル化雛形と slash command テンプレ修正雛形を追加
+- D: 4.4 (誤検出を避ける条件) に guarded read の例外を追加
+- E: レポート雛形に「判定根拠」「反証可能性」の行を追加。TL;DR の主因内訳に簡潔な日本語説明を併記
+
+優先度 2:
+
+- F: 3.1 にルール抽出元の優先順位を明記
+
+優先度 3 (今回見送り):
+
+- G1, G2: 軽微なので実害が小さい
+
+### 2026-05-06: 適用した修正サマリ
+
+`plugins/agent-coach/skills/detect-rework-and-violations/SKILL.md` への変更:
+
+1. **概要 / description フロントマター** — 検出対象を 3 種（手戻り / 違反 / **クロスセッション反復追加指示**）に拡張。改善カテゴリを 5 → 6（**F. 反復指示の昇格**）に拡張。スキルの目的を「**追加指示の最小化**」と明記
+2. **手順 3.1（ルール抽出元）** — 抽出元の優先順位を表化。session reminder（system prompt 由来）を最優先に。"Bash tool 説明由来の cd 禁止のような重要ルールを取り逃す" 警告を追加
+3. **手順 4.1（手戻りシグナル）** — 否定語ベース (a) だけでは穏やかな日本語ユーザーの追加指示を取り逃す警告。**(e) post-completion supplement** カテゴリを新設（完了寸前の otherwise 追加指示）
+4. **手順 4.2.1（slash command コンテキストガード）** — 違反検出の前段に「直前数ターンの slash command 起動を確認、template 内で許可されているなら違反扱いしない」必須ステップを新設。代表的な許可表（`/autodev-create-pr` で commit/push、etc.）と、これを省くと 14 件中 10 件誤報告するという実測根拠を併記
+5. **手順 4.4（誤検出条件）** — guarded read (`cat ... 2>/dev/null`)、read-only 情報収集 Bash、`.ai-agent/tasks/` 配下の `Write` 等を違反扱いしない例外を追加
+6. **手順 4.5（クロスセッション反復追加指示の集約）** — **本タスクの主目的**。命令キー語彙、n-gram + キーフレーズの 2 段クラスタリング、≥2 セッション要件、トピック要約までの集約手順を新設
+7. **手順 5（主因分類）** — 6 番目「**反復指示**」を追加。クロスセッション傾向に「F カテゴリを最優先で提案」を追記
+8. **手順 6F（反復指示の昇格）** — 4 つの昇格先（F-1 memory / F-2 プロジェクト CLAUDE.md / F-3 skill template / F-4 グローバル CLAUDE.md）の選択基準と注意点を新設。詳細雛形は `reference/promotion-templates.md` に切り出し
+9. **手順 7（レポート生成）** — 「分析過程を知らない人が読んで判断できる」ための (a) 判定根拠 / (b) 反証可能性 / (c) 専門用語の 1 行注釈 / (d) 推奨アクションは具体的対象パスまで を必須化。レポート雛形に「クロスセッション反復追加指示」セクションを最重要として最初に配置。各 finding に「判定根拠」「反証可能性」行を追加
+10. **TOP3 優先度** — Tier 1 に「クロスセッション反復追加指示が 2 セッション以上」を最優先で追加
+11. **手順 8（実装ヒント）** — Python 骨格コードの完全版を `reference/implementation.md` に切り出し、本体は短いポインタにまとめた（slash command フレーム抽出 + クロスセッションクラスタリングの最小実装を含む）
+12. **本体サイズの圧縮** — best practices の「SKILL.md は 500 行以下推奨」に従い、746 → 475 行に削減。詳細サンプル・実装ヒントを `reference/` 配下に切り出し
+
+新規ファイル:
+
+- `plugins/agent-coach/skills/detect-rework-and-violations/reference/promotion-templates.md` — F カテゴリ（反復指示の昇格）の memory ファイル / CLAUDE.md / slash command template 修正の雛形・実例集
+- `plugins/agent-coach/skills/detect-rework-and-violations/reference/implementation.md` — Python ヒアドキュメント実装の骨格（rework 検出 / 違反検出 + slash command ガード / クロスセッションクラスタリング）と「手で目視 + Grep」の代替手段
+
+検証結果: `python3 scripts/validate-skills.py` → 23 ファイル 0 error。
+
+### 2026-05-06: 第 2 ラウンド評価（fresh エージェントによる独立試用）
+
+- 修正後の SKILL.md を、本会話のコンテキストを持たない team member agent (general-purpose) に spawn し、同一の 10 セッションに対して独立試用させた
+- レポート: `.ai-agent/tmp/20260506-rework-violations/report-fresh.md`（288 行）
+
+#### 改善が確認できた点
+
+| 観点 | 旧版 | fresh 版 |
+| --- | --- | --- |
+| 手戻り検出 | 0 件（NEG_WORDS のみ） | **2 件**（post-completion supplement パターンで検出） |
+| 違反候補誤検出率 | 14 件中 13 件誤検出 (93%) | 12 件中 5 件 を slash command ガードで除外 (42%)、残り 7 件は真の違反候補 |
+| クロスセッション反復追加指示 | 検出機能なし | **2 種**を誤検出ゼロで検出（task README / PR 言語） |
+| セッション識別性 | UUID のみで読めない | topic 列で `/autodev-start-new-task「<args>」` 等が一目で識別可能 |
+| 各 finding の判定根拠・反証 | 無し | 全 finding に併記（読み手単独で判断可能） |
+| 新カテゴリの発見 | なし | **トリガミス型違反**（`/autodev-start-new-task` template が `/autodev-create-pr` 起動を指示しているのに 6 セッション中 5 で generic 実装で代替）を独自に発見 |
+
+#### fresh エージェントの自己評価で挙がった残改善点
+
+3 つすべて反映:
+
+- **(e1) `Base directory for this skill: .../skills/<name>` を slash command frame として認識する**ロジックが reference 側にない → SKILL.md 4.2.1 step 1 と reference/implementation.md `collect_slash_command_frames` を 2 系統対応に強化
+- **(e2) 直前ユーザー発話の明示指示チェックの自動化**（手動補正していた `task README も含めて` のようなケース）→ SKILL.md 4.2.1 に step 4 を追加、reference/implementation.md に `has_user_explicit_instruction` を追加
+- **(e3) template が呼べと指示している skill を呼ばずに generic 実装するトリガミス型を 4.2 代表例に追加** → 4.2 表に 1 行追加
+
+#### fresh ラウンドが検出した最重要 finding（PR ボディに反映）
+
+このリポジトリ自体が以下の問題を抱えていることが判明した:
+
+1. `/autodev-create-pr` を毎回呼ぶべきところで Claude が直接 `git commit + push + gh pr create` で代替している（5 セッション横断のトリガミス）
+2. `/autodev-create-pr` 完了後にユーザーが「task README も含めて」「PR を日本語に」と毎回追加指示している（追加指示の最小化目的に直結する反復）
+
+→ **これらは本タスクのスコープ外**。本タスクは detect-rework-and-violations スキルの改善であり、autodev-create-pr / autodev-start-new-task テンプレートの修正は別タスクで扱うべき。本 PR の説明にこれを finding として記載し、別タスクへの種にする。

--- a/plugins/agent-coach/skills/detect-rework-and-violations/SKILL.md
+++ b/plugins/agent-coach/skills/detect-rework-and-violations/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Analyze recent Claude Code transcripts to detect rework loops (direction corrections, redo cycles, post-completion rollbacks) and instruction violations against project rules (CLAUDE.md, skill definitions, memory files, system reminders), then propose concrete remediation across five categories — prompt rewrites, rule wording improvements, Hook-based deterministic enforcement, rewind workflow advice, and skill description fixes. Use when the user feels work needs frequent redoing, the model ignores established rules, you want to audit how often the model went off-track, or you need actionable rewrites for prompts and rules.
+description: Analyze recent Claude Code transcripts to detect rework loops (direction corrections, redo cycles, post-completion supplements), instruction violations against project rules (CLAUDE.md, skill definitions, memory files, system reminders), and cross-session repeated additional instructions that the user keeps re-issuing every session. Then propose concrete remediation across six categories — prompt rewrites, rule wording improvements, Hook-based deterministic enforcement, rewind workflow advice, skill description fixes, and promotion of repeated user instructions to memory/CLAUDE.md/skill templates. The core goal is to minimize how often the user has to repeat the same additional instructions across sessions. Use when the user feels work needs frequent redoing, the model ignores established rules, the user keeps giving the same correction every session, you want to audit how often the model went off-track, or you need actionable rewrites for prompts and rules.
 allowed-tools: Bash, Read, Write, Glob, Grep
 ---
 
@@ -7,106 +7,129 @@ allowed-tools: Bash, Read, Write, Glob, Grep
 
 ## 概要
 
-ユーザーの transcript JSONL を分析し、**手戻り**（方向修正ループ・差し戻し・「やり直し」指示）と **指示違反**（CLAUDE.md / SKILL.md / memory / system reminder で示されたルールに対する違反）を検出する特化スキル。本スキルは:
+ユーザーの transcript JSONL を分析し、以下 3 種を検出する特化スキル:
 
-1. プロジェクトと session 内に存在する**ルールを構造化抽出**（"必ず X する" / "Y してはいけない" / skill description の Use when / Distinct from / SKIP 条件）
-2. 手戻り事例を **3 点組（元プロンプト → Claude の解釈 → ユーザーの修正）**で抽出
-3. 指示違反事例を **(ルール文, 違反した assistant 行動, 違反ターン)** で抽出
-4. 主因を 5 種に分類（**曖昧プロンプト / ルール埋没 / 検証なし完了 / トリガミス / コンテキストロット起因**）
-5. 改善提案を 5 カテゴリに分類して具体的な書き換え案を提示（**A. プロンプト書き換え / B. ルール明文化 / C. Hook 化 / D. 巻き戻し運用 / E. skill description 改善**）
+1. **手戻り**（方向修正・差し戻し・**完了寸前の追加指示** post-completion supplement）
+2. **指示違反候補**（CLAUDE.md / SKILL.md / memory / system reminder のルール違反。ただし**直前 slash command で許可された行動は除外**）
+3. **クロスセッション反復追加指示**（複数セッションで繰り返し出ている同一の追加指示。**本スキルの主目的**「追加指示の最小化」の中心ターゲット）
 
-なお、手戻り・違反はコンテキストロット（履歴肥大による初期指示の忘却）が根本原因であるケースが少なくない。違反ターンが session 後半に集中している、初期 reminder で示されたルールが消失している等のシグナルが揃う場合は、本スキルの文面・運用レベルの改善より先にコンテキストロット側の対処（断点 / MEMORY 化 / Compact Instructions）を検討する。
+最終ゴールは、ユーザーが**毎回同じ追加指示を出さなくて済むようにすること**。単発の手戻り・違反だけでなく「何度も繰り返される追加指示」を集約して memory / CLAUDE.md / skill template への昇格候補として提示する。
+
+主因は 6 種に分類: 曖昧プロンプト / ルール埋没 / 検証なし完了 / トリガミス / コンテキストロット起因 / **反復指示**。改善は 6 カテゴリ: A プロンプト書き換え / B ルール明文化 / C Hook 化 / D 巻き戻し運用 / E skill description 改善 / **F 反復指示の昇格**。
+
+なお rot 起因（履歴肥大による初期指示忘却）が根本原因の場合は、本スキルの B/C 改善より先にコンテキストロット側の対処（断点 / MEMORY 化 / Compact Instructions）を優先する。
 
 ## 前提条件
 
 - macOS / Linux 環境（transcript パスは `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`）
-- 分析対象セッションが少なくとも 1 件存在すること（パターン抽出には 3 件以上推奨。1〜2 件しかないときは「単発の手戻り / 違反」の報告にフォールバック）
-- （任意）プロジェクトの `CLAUDE.md`・`~/.claude/CLAUDE.md`・`~/.claude/projects/<encoded-cwd>/memory/*.md`・`<repo>/.claude/skills/**/SKILL.md`・`plugins/*/skills/**/SKILL.md` が読めると、ルール抽出の精度が上がる
+- 分析対象セッションが 1 件以上（パターン抽出には 3 件以上推奨。1〜2 件のときは「単発の手戻り / 違反」報告にフォールバック）
+- ルール抽出元として `<repo>/CLAUDE.md`・`~/.claude/CLAUDE.md`・memory ファイル・skill 定義が読めると精度が上がる
+
+## 関連リソース
+
+- `reference/implementation.md` — Python ヒアドキュメント実装の骨格と最小サンプル
+- `reference/promotion-templates.md` — F カテゴリの memory ファイル / CLAUDE.md / skill template 修正の雛形
 
 ## 手順
 
 ### 1. 分析対象セッションの決定
 
-- **対象プロジェクト**: 現在の cwd に対応する `~/.claude/projects/<encoded-cwd>/`。`Glob` または `ls ~/.claude/projects/ | grep <repo-basename>` で実在ディレクトリを特定
-- **対象セッション**: そのディレクトリ配下の `*.jsonl` を mtime 降順で**最新 5〜10 セッション**（パターン化に複数セッション推奨）
+- **対象プロジェクト**: 現在の cwd に対応する `~/.claude/projects/<encoded-cwd>/`
+- **対象セッション**: そのディレクトリ配下の `*.jsonl` を mtime 降順で**最新 5〜10 件**
 - **除外**: 実行中セッション（mtime 最新の 1 件）。ユーザー明示指定時は除外しない
-- **件数の調整**: ユーザーから指定があれば従う
+- **件数調整**: ユーザー指定があれば従う
 
-候補セッション一覧（ファイル名 / mtime / サイズ / 概算ターン数）を簡潔に提示してから処理に進む。
+候補一覧（ファイル名 / mtime / サイズ / 概算ターン数）を簡潔に提示してから処理に進む。
 
-### 2. JSONL の構造把握（手戻り・違反検出に使うフィールド）
+#### 1.1 セッショントピックの抽出（**レポート読解性のため必須**）
+
+セッション ID（UUID）だけ提示しても**読み手が中身を識別できない**ため、各セッションに「**何をしていたか**」を 1 行で添える。本スキルのレポート全体（事例リスト・反復指示クラスタ・統計サマリ）でこの topic を併記すること。
+
+抽出ロジック（優先順位順、最初に見つかったものを採用）:
+
+1. **`<command-name>/autodev-start-new-task</command-name>` または類似の topic-defining コマンド**（`/autodev-start-new-project`, `/autodev-start-new-survey`, `/autodev-discussion`, `/autodev-create-issue`, `/autodev-replan`, `/autodev-steering`, `/init`）の `<command-args>` 内容 → `「<args 抜粋 80 字>」`
+2. **`<command-name>/autodev-create-pr</command-name>` または `/autodev-import-review-suggestions` / `/autodev-review-pr`** → `<command> (branch: <branch 名>)` （branch から topic を推測）
+3. その他の `<command-name>`（`/detect-context-rot`, `/recommend-bash-allowlist`, `/security-review`, `/review` 等）→ コマンド名を topic とする
+4. 自由入力の最初の user 発話（`Base directory for this skill:` で始まるテンプレ本文や `<bash-*>` / `<local-command-*>` で始まるブロックは除外）→ 冒頭 80 字
+
+除外する noise 系コマンド: `/clear`, `/compact`, `/help`, `/rewind`, `/fast`（topic にならない）。これらは飛ばして次の候補を見る。
+
+実装は `reference/implementation.md` の `extract_topic` を参照。
+
+候補一覧の提示時にも topic を併記する:
+
+```
+session    branch                                  topic
+b277cc6e   main                                    /autodev-start-new-task「recommend-bash-allowlist を実際に使用してみて評価」
+301d1256   main                                    /autodev-start-new-task「agent-coach スキル自体は削除しましょう」
+29734a5f   feature/add-bash-allowlist-...          /autodev-create-pr (branch: add-bash-allowlist-recommender-skill)
+...
+```
+
+### 2. JSONL 構造（参照する主要フィールド）
 
 | 場所 | 用途 |
 | --- | --- |
-| `type == "user"` の `message.content` | ユーザー入力（修正指示・元指示・否定語の検出） |
-| `type == "assistant"` の `message.content[]` の `text` | Claude の応答テキスト（「Wait, you mean...」「I'll commit now」等の確認/宣言パターン） |
+| `type == "user"` の `message.content` | ユーザー入力（修正指示・元指示・否定語・命令キー） |
+| `type == "assistant"` の `message.content[]` の `text` | Claude の応答テキスト（確認 / 完了宣言パターン） |
 | `type == "assistant"` の `message.content[]` の `tool_use` | 実行された行動（違反判定の対象） |
-| `type == "system"` 内の skill 一覧 / CLAUDE.md / システム reminder | 当該セッションで有効だったルール |
-| 各レコードの timestamp / 順序 | ターン番号、隣接性の判定 |
+| user message 内の `<system-reminder>` ブロック | session に注入された system prompt 由来ルール（最重要抽出元） |
+| 各レコードの timestamp / 順序 | ターン番号、隣接性 |
 
-**1 ファイル全文 Read は避ける**。1MB 超は `Bash` で `python3` ヒアドキュメントで集計する（実装ヒント参照）。
+**1 ファイル全文 Read は避ける**。1MB 超は `Bash` で `python3` ヒアドキュメントで集計する（`reference/implementation.md` 参照）。
 
 ### 3. ルールの構造化抽出
 
-「ルール」とは `必ず X する` / `Y してはいけない` / `Z の場合は ...` のような **assistant の行動を制約する記述**。違反検出の左辺。
+「ルール」とは `必ず X する` / `Y してはいけない` / `Use when ...` のような **assistant の行動を制約する記述**。違反検出の左辺。
 
-#### 3.1 プロジェクトファイルから
+#### 3.1 抽出元の優先順位
 
-以下を `Read` で確認（存在する範囲で）:
+| 優先 | ファイル / 場所 | 役割 |
+| --- | --- | --- |
+| 1 | session JSONL の `<system-reminder>` ブロック内 `# claudeMd`、Bash tool 説明、Auto Mode 宣言 | system prompt 由来のルールが最も確実に抽出できる |
+| 2 | `~/.claude/CLAUDE.md` | グローバル user 設定（コミット運用 / `--no-verify` 禁止 / emoji 禁止 / Read 優先など恒久ルール） |
+| 3 | `<repo>/CLAUDE.md`、`<repo>/.claude/CLAUDE.md` | プロジェクト固有ルール |
+| 4 | `~/.claude/projects/<encoded-cwd>/memory/*.md` | auto memory（feedback / project / user / reference） |
+| 5 | `<repo>/.claude/skills/**/SKILL.md`、`plugins/*/skills/**/SKILL.md` | skill 個別の Use when / SKIP 条件、手順内の禁止条文 |
 
-- `<repo>/CLAUDE.md`
-- `<repo>/.claude/CLAUDE.md`
-- `~/.claude/CLAUDE.md`
-- `~/.claude/projects/<encoded-cwd>/memory/*.md`（auto memory）
-- `<repo>/.claude/skills/**/SKILL.md` の本文
-- `plugins/*/skills/**/SKILL.md` の本文
+**1 を見ずに 2〜5 だけ見ると、Bash tool 説明由来の `cd <current-directory>` 禁止のような重要ルールを取り逃す**。
 
-抽出対象の語彙パターン（日英混在）:
+語彙パターン（日英混在）:
 
-- `必ず`, `しなければならない`, `MUST`, `IMPORTANT`, `Always`
-- `してはいけない`, `禁止`, `NEVER`, `NEVER use`, `Never`, `Don't`, `避ける`
-- `〜のとき`, `〜の場合`, `Use when`, `When ...`, `If ...`
-- `〜と区別する`, `Distinct from`, `Not for`, `SKIP when`
+- 肯定: `必ず`, `しなければならない`, `MUST`, `IMPORTANT`, `Always`
+- 否定: `してはいけない`, `禁止`, `NEVER`, `Never`, `Don't`, `避ける`
+- 条件: `〜のとき`, `〜の場合`, `Use when`, `When ...`, `If ...`
+- 区別: `〜と区別する`, `Distinct from`, `Not for`, `SKIP when`
 
-各ルールを `(出典ファイル, 該当行 or 抜粋, 否定/肯定, 適用条件)` の組で保持。
+各ルールを `(出典, 抜粋, 否定/肯定, 適用条件)` の組で保持。
 
-#### 3.2 当該セッションの system reminder から
+#### 3.2 ユーザーが session 中に動的に与えたルール
 
-`type == "system"` の reminder（または `tool_result` 配下）には、その時点で有効な以下が含まれることがある:
-
-- `# claudeMd` ブロック（プロジェクト CLAUDE.md の現在の内容）
-- 利用可能スキル一覧（description にトリガ条件・SKIP 条件を含む）
-- 個別スキルの SKILL.md 本文（Skill ツール呼び出し時に注入される）
-- Auto Mode / Permission Mode の宣言
-
-セッション中に内容が切り替わる場合は、各 user 入力時点で「直前に観測した reminder」を採用する。
-
-#### 3.3 ユーザーが直前に与えたルール
-
-直前のユーザー指示で「以後は X しないで」「次回からは Y を使って」と発話されたら、その時点以降に対する**新規ルール**として動的に追加する。
+「以後は X しないで」「次回からは Y を使って」と発話されたら、その時点以降の**新規ルール**として動的に追加する。
 
 ### 4. シグナル抽出
 
-#### 4.1 手戻りシグナル（観点 2 系統）
+#### 4.1 手戻りシグナル
 
-ユーザーメッセージ中の以下を検出:
+否定語 (a) だけでは穏やか・建設的口調のユーザー（特に日本語話者）の追加指示を取り逃す。**(b)〜(g) を必ず併用**:
 
-- **否定・修正語**: `no`, `not that`, `not what I meant`, `instead`, `actually`, `stop`, `wait`, `違う`, `そうじゃなくて`, `やめて`, `いや`, `じゃなくて`, `戻して`, `revert`, `undo`, `元に戻して`
-- **短い即時返信**: 直前 assistant ターンへの即応で、ユーザーメッセージが 50 文字未満（不満の即時表明シグナル）
-- **同一トピック再指示**: 直近 3 ターン以内にユーザーが同じ対象（同じファイル名・関数名・機能名）を再度言及して別の指示を出している
-- **完了後の差し戻し**: assistant が「完了しました」「Done」「PR を作成しました」等の宣言をした次のユーザー入力に否定・修正語が含まれる
-- **assistant の確認パターン**: assistant 応答に `Wait, you mean ...?`, `Did you mean ...?`, `Let me clarify ...`, `すみません、もう一度確認させてください` 等が現れる
-- **`/rewind` / `Esc Esc`**: ユーザーが巻き戻し操作を行った痕跡（`type == "user"` で `<command-name>/rewind</command-name>` 等）
+- **(a) 否定・修正語**: `no`, `not that`, `instead`, `actually`, `stop`, `wait`, `revert`, `undo`, `違う`, `そうじゃなくて`, `やめて`, `いや`, `じゃなくて`, `戻して`, `元に戻して`, `やり直し`
+- **(b) 短い即時返信**: 直前 assistant ターンへの即応で 50 文字未満（不満の即時表明）
+- **(c) 同一トピック再指示**: 直近 3 ターン以内にユーザーが同じ対象を再度言及して別の指示
+- **(d) 完了後の差し戻し**: 完了宣言の次の user 入力に否定・修正語が含まれる
+- **(e) post-completion supplement（完了寸前の追加指示）**: assistant が**完了宣言・PR 作成・コミット・最終 Write/Edit** の直前直後に来るユーザー入力で、**否定語を含まないが追加要件を出している**もの。命令キー `してください` / `しましょう` / `お願い` / `含めて` / `に変更` / `please` / `also` などを含み、内容が「言語を変える」「もっと含める」「追加で X して」のような**増分追加指示**。**否定語が無いため (a) からは漏れるが、ユーザーの軌道修正コストとしては (a) と同等以上に重要**。クロスセッション分析（4.5）でこの (e) パターンが横断的に多いと、F カテゴリの主たる材料になる
+- **(f) assistant の確認パターン**: assistant 応答に `Wait, you mean ...?` / `Did you mean ...?` / `Let me clarify ...` / `すみません、もう一度確認` 等
+- **(g) `/rewind` / `Esc Esc`**: 巻き戻し操作の痕跡
 
 各シグナル検出時、**直前の元プロンプト**を 1 つ前の `type == "user"` から特定し、紐付けて保持する。
 
-#### 4.2 指示違反シグナル（観点 3 系統）
+#### 4.2 指示違反シグナル
 
-3 で抽出したルール各 R について、当該セッションの assistant 行動を走査し、違反候補を検出:
+3 で抽出したルール各 R について、当該セッションの assistant 行動を走査:
 
 - ルールが「必ず X する」型 → 該当文脈で X が行われていない `tool_use` シーケンス
 - ルールが「Y してはいけない」型 → 該当文脈で Y が `tool_use` または assistant text に出現
-- ルールが skill description の Use when / SKIP when → 該当ユーザー入力時に当該 skill を呼ばずに別手段で対応している
+- skill description の Use when / SKIP when → 該当ユーザー入力時に当該 skill を呼ばずに別手段で対応
 
 代表例:
 
@@ -117,84 +140,125 @@ allowed-tools: Bash, Read, Write, Glob, Grep
 | 「テスト追加・実行」 | 実装後に `pytest` / `npm test` を実行せず終了 |
 | 「コメントは書かない」 | 新規コード追加で `//`, `#` コメント挿入 |
 | 「README は要求時のみ」 | `*.md` の `Write` 新規作成（要求なし） |
-| 「英語で書く / 日本語で書く」 | 指定言語と異なる出力 |
 | skill description Use when ... | 該当ケースで Skill ツール未呼び出し（generic 実装） |
+| **template が「`/<other-skill>` を起動する」と指示している** | 該当文脈で `<command-name>/<other-skill></command-name>` も `Base directory for this skill: .../<other-skill>` も無く、generic 実装で代替している（**トリガミス + ルール埋没の複合違反**。例: `/autodev-start-new-task` が「PR は `/autodev-create-pr` を使用する」と指示しているのに直接 `git commit` + `gh pr create` を実行） |
+
+##### 4.2.1 slash command コンテキストガード（**必須**）
+
+ルール違反候補を確定する前に、**直前 N ターン以内（推奨 N = 20、または最後の `<command-name>` 出現以降）にユーザーが起動した slash command** を特定し、template 本文で当該アクションが許可・要求されていないかを確認する。許可されているなら違反扱いしない。
+
+具体的には:
+
+1. `type == "user"` の `message.content` で以下のいずれかを時系列で集める。直近のものを「現在のフレーム」とする:
+   - `<command-name>/<name></command-name>` を含むレコード（slash command 起動の正規形）
+   - **`Base directory for this skill: <path>/skills/<name>` を含むレコード**（slash command 起動時に template 本文と一緒に注入される自由貼付け版。`<command-name>` が無いので 1 のみだと取りこぼす）
+2. 同 user message の text ブロック内 template 本文を読む。違反ルールに該当する行為が template 内で「実行する」と明示されていれば**許可済み**として違反候補から除外
+3. `<command-args>` のユーザー追加要望も個別許可になっていないか確認
+4. **直前ユーザー発話の明示指示**も確認: 違反ターン直前の user 発話が「コミットして」「PR にしましょう」「task README も含めて」のような該当アクションを直接要求しているなら、それも「ユーザー明示指示」として違反候補から除外する。命令キーマッチ（`コミット` / `PR` / `commit` / `push`）+ 動詞語尾（`して` / `しましょう` / `してください`）で判定
+
+代表的な「slash command が許可している行動」:
+
+| slash command | 許可される行動 |
+| --- | --- |
+| `/autodev-create-pr` | `git add` / `git commit` / `git push -u` / `gh pr create` |
+| `/autodev-start-new-task` | `git checkout -b <task-name>`、タスクディレクトリ・README.md の `Write` |
+| `/autodev-import-review-suggestions` | レビュー指摘に対するファイル `Edit` / `Write` |
+| `/autodev-replan` / `/autodev-steering` | 該当ドキュメントの `Edit` / `Write` |
+| `/autodev-switch-to-default` | `git checkout main` / `git pull` |
+
+**4.2.1 を入れずに違反検出を回すと `/autodev-create-pr` 経由のコミットを毎回違反として誤報告する**（実測: 試用時に 14 件中 10 件が当該誤検出）。violation 候補ごとに「直前 slash command フレーム」と「template 内でのアクション許可有無」を 1 行で記録し、レポートの判定根拠に書き出す。
 
 #### 4.3 3 点組の組み立て
 
-各手戻り・違反イベントについて以下を 1 レコードにまとめる:
+各イベントを 1 レコードに:
 
 ```
 {
   "kind": "rework" | "violation",
-  "session": "<id>",
-  "turn": <int>,
+  "session": "<id>", "turn": <int>,
   "rule_or_signal": "<ルール文 or 修正語パターン>",
   "user_original": "<元プロンプト抜粋>",
   "claude_action": "<assistant の応答 / tool_use 要約>",
-  "user_correction": "<修正プロンプト抜粋>",  // rework のみ
-  "rule_source": "<出典>"  // violation のみ
+  "user_correction": "<修正プロンプト抜粋>",   // rework のみ
+  "rule_source": "<出典>",                       // violation のみ
+  "slash_command_frame": "<command-name or null>", // violation のみ
 }
 ```
 
-#### 4.4 検出の精度に関する注意
+#### 4.4 誤検出を避ける条件
 
-- **誤検出を避ける条件**:
-  - 否定語があってもそれが過去の話題への言及（"yesterday I said no to ..."）なら手戻りではない
-  - ルール文の「IMPORTANT」が一般的注意であって個別アクションを禁じていない場合は違反扱いにしない
-  - ユーザー自身が一旦容認した行動（assistant が確認 → ユーザー OK）後の方針変更は手戻りに数えない
-  - 計画的な「ステップ 2 として行います」を完了後の差し戻しと誤判定しない
-- **断定を避ける**: ルール本文の解釈には幅があるため、複数シグナルが揃ったときに「違反候補」のトーンで提示する
+- 否定語が過去の話題への言及（"yesterday I said no to ..."）なら手戻りではない
+- ルール文の「IMPORTANT」が一般的注意であって個別アクションを禁じていない場合は違反扱いにしない
+- ユーザーが一旦容認した行動（assistant が確認 → ユーザー OK）後の方針変更は手戻りに数えない
+- 計画的な「ステップ 2 として行います」を完了後の差し戻しと誤判定しない
+- **slash command 経由で許可された行動**は違反扱いにしない（4.2.1 を必ず適用）
+- **guarded read** (`cat <file> 2>/dev/null`、pipeline `|` の一部、heredoc delimiter、`< file` リダイレクトと組み合わせた `cat`) は「Read を使え」ルールの違反扱いにしない（`Read` はファイル不在時にエラー → `cat ... 2>/dev/null` は妥当な代替）
+- `git status`, `git diff`, `git log`, `git rev-parse`, `gh pr view` のような **read-only 情報収集 Bash** はコミット系 slash command 配下でなくても違反扱いしない
+- `Write` で新規 `*.md` を作っても、パスが `.ai-agent/tasks/`, `.ai-agent/projects/`, `.ai-agent/surveys/`, `.ai-agent/tmp/`, `<repo>/<skills-dir>/**/SKILL.md`, `<repo>/.ai-agent/tmp/**/report.md` 配下なら autodev / agent-coach 系 skill 由来の正当な作成として違反扱いしない
+
+**断定を避ける**: ルール本文の解釈には幅があるため、複数シグナルが揃ったときに「違反候補」のトーンで提示する。レポートには必ず**判定根拠**（なぜ違反と見なしたか）と**反証材料**（誤検出の可能性）を 1 行ずつ添える。
+
+#### 4.5 クロスセッション反復追加指示の集約（**本スキルの主目的**）
+
+ユーザーが**毎回同じ追加指示を出している**ことを検出するのが本スキルの中心ロジック。手戻り 4.1.(e) の post-completion supplement や違反 4.2 が単発の事象だが、(e) の追加指示が**複数セッションで反復**しているなら、それは「skill / template / memory に組み込まれていない暗黙ルール」のシグナル。
+
+##### 集約手順
+
+1. **候補抽出**: 各セッションから「ユーザー実発話のうち 10〜300 文字、命令キーを含むもの」を集める。命令キー例:
+   - 日本語: `してください`, `お願い`, `しないで`, `避けて`, `しましょう`, `ましょう`, `にして`, `に変えて`, `に直して`, `に変更`, `追加して`, `含めて`, `含めましょう`, `必ず`, `ではなく`
+   - 英語: `please`, `don't`, `must`, `always`, `never`, `instead`, `also`, `make sure`, `prefer`
+   - スラッシュコマンド起動 (`<command-name>`) や bash 入出力ブロック (`<bash-input>` / `<bash-stdout>` / `<local-command-*>`) は除外
+2. **クラスタリング**（同セッション内のクラスタ化は除外）:
+   - **substring n-gram 一致 (Jaccard)**: 文字 4-gram 集合を作って閾値 0.30 以上のペアをクラスタ化
+   - **キーフレーズ一致**: 名詞・固有名詞らしい連続文字列（英数 + 日本語混在 3 文字以上）を抽出し、共通キーフレーズが 2 つ以上あるペアもクラスタ化
+   - 例: `PRタイトルと本文を日本語にしましょう` と `PRタイトル、説明も日本語にしてください` は n-gram Jaccard が低くても、キーフレーズ `PRタイトル` + `日本語` の共通でクラスタ化
+3. **絞り込み**: **2 セッション以上**で出現したクラスタのみを「反復追加指示」として採用
+4. **トピック要約**: 各クラスタにトピック名を付ける（例: 「PR タイトル/本文を日本語に」「task README を PR に含める」）
+
+クラスタごとに「**昇格先**」を決定する。詳細・雛形は `reference/promotion-templates.md` 参照。
+
+10 セッション分析しても 2 セッション以上の反復クラスタが 0 件なら、**「クロスセッション反復追加指示は検出されなかった」と明示**してフォールバックする。
 
 ### 5. パターン化（主因分類）
 
-検出した 3 点組レコードを以下の主因軸で集約する。1 件が複数主因に当てはまる場合は最も影響度が高い主因を main、他は補足参照。
-
 | 主因 | シグナル | 代表的改善カテゴリ |
 | --- | --- | --- |
-| **曖昧プロンプト** | 元プロンプトに具体性が乏しい（"いい感じに", "適切に", "直して" 単独） / Claude が `Wait, you mean ...?` を返した | A（プロンプト書き換え） |
-| **ルール埋没** | ルール出典が CLAUDE.md の中盤以降 / system reminder の長文末尾 / 違反が複数セッションで反復 | B（ルール明文化） |
-| **検証なし完了** | 「完了」宣言の直後に差し戻し / テスト / 動作確認の `tool_use` が無いまま finish | C（Hook 化）または B（ルール明文化） |
-| **トリガミス** | 該当 skill の Use when にマッチしているのに Skill 未呼び出しで generic 対応 | E（description 改善） + 必要なら B |
-| **コンテキストロット起因** | 違反ターンが推定 rot 始点以降 / 同セッション後半でのみ違反 / 初期指示が消失している | D（巻き戻し）+ コンテキストロット側の対処（断点 / MEMORY 化 / Compact Instructions）を優先 |
+| **曖昧プロンプト** | 元プロンプトに具体性が乏しい / Claude が `Wait, you mean ...?` を返した | A |
+| **ルール埋没** | ルール出典が CLAUDE.md の中盤以降 / system reminder の長文末尾 / 違反が複数セッションで反復 | B |
+| **検証なし完了** | 「完了」宣言の直後に差し戻し / テスト・動作確認の `tool_use` が無いまま finish | C または B |
+| **トリガミス** | 該当 skill の Use when にマッチしているのに Skill 未呼び出しで generic 対応 | E + 必要なら B |
+| **コンテキストロット起因** | 違反ターンが session 後半に集中 / 初期指示が消失している | D + コンテキストロット側の対処（断点 / MEMORY 化 / Compact Instructions）を優先 |
+| **反復指示** | 4.5 のクラスタが複数セッション横断で見つかった / post-completion supplement が複数セッションで反復 | **F** |
 
-#### 5.1 セッション横断の傾向
+#### セッション横断の傾向
 
-- 同一ルールが **複数セッションで違反** → ルール文言改善 + Hook 化が候補
-- 同一プロンプトパターンで **複数回手戻り** → プロンプト雛形化 / skill 化候補
+- 同一ルールが複数セッションで違反 → ルール文言改善 + Hook 化が候補
+- 同一プロンプトパターンで複数回手戻り → プロンプト雛形化 / skill 化候補
 - 完了後差し戻しが頻発 → 完了ゲート Hook（Stop）を提案
+- **同一の追加指示が複数セッションで反復** (4.5) → **F カテゴリを最優先で提案**。これが本スキルの主成果物
 
 ### 6. 改善提案カテゴリへのマッピング
 
-検出した 3 点組を以下 5 カテゴリに振り分け、**書き換え後の文面まで提示**する。「もっと明確に」だけでは終わらせない。
+検出した 3 点組とクラスタを以下 6 カテゴリに振り分け、**書き換え後の文面まで提示**する。「もっと明確に」だけで終わらせない。
 
-#### A. プロンプト書き換え（曖昧プロンプト → 具体プロンプト）
+#### A. プロンプト書き換え（曖昧 → 具体）
 
 雛形:
 
 ```
-[元プロンプト]
-"認証直して"
-
-[改善後]
-"src/auth/login.ts:42 の `if (user.email)` が falsy 値を見落としている。
- `if (user?.email != null)` に修正し、tests/auth.test.ts:120 の
- `it('rejects empty email')` をパスさせて確認。他のテストはそのまま。"
+[元] "認証直して"
+[改善後] "src/auth/login.ts:42 の `if (user.email)` が falsy 値を見落としている。
+         `if (user?.email != null)` に修正し、tests/auth.test.ts:120 の
+         `it('rejects empty email')` をパスさせて確認。他のテストはそのまま。"
 ```
 
-押さえるポイント:
-
-- ファイルパス + 行番号 + 関数名で **対象を一意化**
-- **期待挙動と検証方法**を 1 行で
-- **触らない範囲**を明示（暗黙の差分を防ぐ）
+押さえるポイント: ファイルパス + 行番号で対象を一意化 / 期待挙動と検証方法を 1 行で / 触らない範囲を明示。
 
 #### B. ルール明文化（埋没 → 上位配置・専用 memory ファイル）
 
-雛形 1: CLAUDE.md 冒頭への昇格
+雛形 1 — CLAUDE.md 冒頭への昇格:
 
 ```markdown
-# プロジェクト名
-
 ## IMPORTANT — must follow
 
 - コミットは明示的指示時のみ。`git commit` を勝手に呼ばない。
@@ -202,7 +266,7 @@ allowed-tools: Bash, Read, Write, Glob, Grep
   - **How to apply:** ユーザーが「コミットして」と言うまで `git status` 提示で止まる
 ```
 
-雛形 2: 専用 memory ファイル化（auto memory 仕様）
+雛形 2 — 専用 memory ファイル化（auto memory 仕様）:
 
 ```markdown
 ---
@@ -214,42 +278,29 @@ type: feedback
 `git commit` をユーザー指示なしで実行しない。
 
 **Why:** 過去にレビュー前コミットで CI を汚し、revert 対応が発生した。
-**How to apply:** ユーザーが「コミットして」と言うまで、`git status` の提示で止まる。
+**How to apply:** ユーザーが「コミットして」と言うまで `git status` の提示で止まる。
 ```
 
 #### C. Hook 化（決定論的強制）
 
-ルール違反が **3 回以上反復** している、または影響が大きいときに昇格提案する。CLAUDE.md は advisory、Hook は deterministic。
-
-代表的 Hook 種別:
+ルール違反が **3 回以上反復**、または影響が大きいときに昇格提案する。CLAUDE.md は advisory、Hook は deterministic。
 
 | 状況 | Hook 種別 | 例 |
 | --- | --- | --- |
 | 完了前のテスト未実行 | Stop | `scripts/require-tests-passed.sh` で exit 2 |
 | 危険コマンド実行 | PreToolUse Safety Gate | `Bash` matcher + `git push --force` 等のブロック |
-| `--no-verify` 使用 | PreToolUse | matcher で `Bash`、`--no-verify` を含む command を exit 2 |
+| `--no-verify` 使用 | PreToolUse | `Bash` matcher、`--no-verify` を含む command を exit 2 |
 | リント違反 | PostToolUse Quality Loop | フォーマッタ自動実行 + 違反箇所を additionalContext に注入 |
 | 同一ルール違反 N 回 | PostToolUse | 違反検出ごとに reminder 注入 |
-
-Hook 設定スニペット例:
 
 ```json
 {
   "hooks": {
     "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          { "type": "command", "command": "scripts/safety-gate.sh" }
-        ]
-      }
+      { "matcher": "Bash", "hooks": [ { "type": "command", "command": "scripts/safety-gate.sh" } ] }
     ],
     "Stop": [
-      {
-        "hooks": [
-          { "type": "command", "command": "scripts/require-tests-passed.sh" }
-        ]
-      }
+      { "hooks": [ { "type": "command", "command": "scripts/require-tests-passed.sh" } ] }
     ]
   }
 }
@@ -266,250 +317,196 @@ Hook 設定スニペット例:
 
 #### E. skill description 改善（トリガミス）
 
-トリガミス起因で違反が起きている場合は、該当 skill の description フロントマターを書き換える。雛形:
+トリガミス起因のとき、該当 skill の description フロントマターを書き換える:
 
 ```yaml
 description: <既存の説明>. Use when <user-keyword-1>, <user-keyword-2>, or <pattern> — for example "<代表ユーザー入力>". Distinct from <other-skill>: this handles <specific-aspect>.
 ```
 
-本スキルでは「違反として顕在化したケース」のみ E に分類し、description 抜粋 + 1 行の修正案にとどめる。description 自体の総点検（未トリガ事例も含む）は本スキルの範囲外。
+本スキルでは「違反として顕在化したケース」のみ E に分類し、description 抜粋 + 1 行の修正案にとどめる。description 自体の総点検は本スキルの範囲外。
+
+#### F. 反復指示の昇格（**本スキルの主出力カテゴリ**）
+
+4.5 のクラスタリングで「複数セッションで繰り返されている追加指示」が見つかったとき、以下のいずれかの昇格先に移して**今後は追加指示無しで効くようにする**ことを提案する:
+
+- **F-1. memory ファイル化** (feedback type) — ユーザー個人の好み / プロジェクト固有の運用ルール
+- **F-2. プロジェクト CLAUDE.md** — プロジェクト全体の運用ルール
+- **F-3. slash command / skill template の修正** — 特定 skill の挙動補正（**最強。手順に組み込めば二度と追加指示が要らない**）
+- **F-4. グローバル `~/.claude/CLAUDE.md`** — リポジトリ非依存な好み
+
+雛形・実例・修正対象パスの選び方は `reference/promotion-templates.md` を参照。
+
+提案時の注意:
+
+- **必ず昇格先を 1 つだけ提案**（複数候補があれば優先順位を 1 行で説明）
+- **証拠（セッション ID + ターン番号）** を最低 2 件添える。1 件しかない反復は F の対象外（A 系で扱う）
+- **配布元 `plugins/<plugin>/skills/<skill>/SKILL.md` を修正する**こと（`.claude/skills/` の symlink だけ書き換えても他環境に伝わらない）
 
 ### 7. レポート生成
 
-レポートは画面に直接ダンプせず、ファイルに書き出す。
+レポートは画面ダンプせずファイルに書き出す。**分析過程を知らない人が読んでも一人で判断できる**ことを念頭に書く:
+
+- (a) 各 finding に **判定根拠**（なぜ違反/手戻り/反復指示と見なしたか）と **反証可能性**（誤検出の可能性が残るか）を 1〜2 行ずつ添える
+- (b) TL;DR の主因内訳には**専門用語の 1 行注釈**を併記する（「rot 起因 = コンテキストロット起因。履歴肥大で初期指示が忘却された結果の違反」など）
+- (c) 推奨アクションは「<何を> を <どこに> に追加 / 修正」と**具体的な対象パスまたは雛形 diff まで書く**
 
 1. 出力ディレクトリ: **`.ai-agent/tmp/<YYYYMMDD>-rework-violations/`**（cwd 基準）。存在しなければ `mkdir -p`
 2. レポート本文: `<出力ディレクトリ>/report.md` を `Write` で書き出す
-3. 画面には以下のみ表示:
-   - レポートファイルパス
-   - 検出件数（rework: N / violation: M）と主因 TOP2
-   - 推奨アクション TOP3
+3. 画面表示はファイルパス + 検出件数（rework: N / violation: M / 反復追加指示: K 種）+ 主因 TOP2 + 推奨アクション TOP3 のみ
 
-#### レポート構造（ファイル本文）
+#### レポート構造
 
 ````markdown
 # Rework & Violation 検出レポート
 
 対象: <セッション一覧 / 期間>
 分析範囲: 最新 N セッション (<earliest> 〜 <latest>)
-抽出ルール: <K> 件（CLAUDE.md / SKILL.md / memory / system reminder）
+抽出ルール: <K> 件
 
 ## TL;DR
 
-- 手戻り: <N> 件 / 指示違反: <M> 件
-- 主因内訳: 曖昧プロンプト <a> / ルール埋没 <b> / 検証なし完了 <c> / トリガミス <d> / rot 起因 <e>
-- 反復違反ルール TOP3: <ルール 1> / <ルール 2> / <ルール 3>
-- → 推奨アクション TOP3 は末尾
+- 手戻り: <N> 件（うち post-completion supplement <p> 件）/ 指示違反候補: <M> 件（うち誤検出 <fp> / 真の違反 <real>）
+- **クロスセッション反復追加指示: <K> 種**（合計 <O> 件、各 ≥2 セッションで反復）
+- 主因内訳:
+  - 曖昧プロンプト <a>（元プロンプトに具体性が乏しい）
+  - ルール埋没 <b>（CLAUDE.md / reminder の長文末尾でルール見落とし）
+  - 検証なし完了 <c>（テスト/動作確認なしの完了宣言からの差し戻し）
+  - トリガミス <d>（Skill 未呼び出しで generic 対応）
+  - コンテキストロット起因 <e>（履歴肥大で初期指示忘却）
+  - **反復指示 <f>**（複数セッションで同じ追加指示が繰り返されている）
+- 反復違反ルール TOP3 / 推奨アクション TOP3 は末尾
 
----
+## セッション一覧（読解用）
+
+| セッション | branch | topic（要約） |
+| --- | --- | --- |
+| `<id1>` | main | /autodev-start-new-task「<引数抜粋>」 |
+| `<id2>` | feature/... | /autodev-create-pr (branch: ...) |
+| ... | ... | ... |
+
+## クロスセッション反復追加指示（**最重要 — 追加指示の最小化に直結**）
+
+### 反復指示 1: 「<トピック名>」 (<出現セッション数> セッション / <件数>件)
+
+**事例**:
+| セッション | topic | ターン | 発話抜粋 |
+| --- | --- | --- | --- |
+| `<id1>` | <topic 要約> | N1 | "..." |
+| `<id2>` | <topic 要約> | N2 | "..." |
+
+**判定根拠**: 4.5 の n-gram + キーフレーズ一致でクラスタ化。共通キーフレーズ: <キー 1>, <キー 2>。
+**反証可能性**: <例: 偶然似た文言だが文脈が違う / 単発タスク特有の文脈>
+**昇格先 (F)**: <F-1 / F-2 / F-3 / F-4>
+**推奨修正**:
+
+```diff
+<具体的な diff か memory ファイル雛形>
+```
+
+(反復指示が 0 件なら「クロスセッション反復追加指示は検出されませんでした」と明示)
 
 ## 手戻りパターン
 
-### パターン 1: <名前 — 例: 完了後の方向修正> (<件数>件 / 主因: <曖昧プロンプト | ...>)
+### パターン 1: <名前 — 例: post-completion supplement> (<件数>件 / 主因: <...>)
 
 **起きていること**:
-- セッション `<id1>` ターン N1: 元 "<元プロンプト抜粋>" → Claude は <要約> → ユーザー "<修正抜粋>"
-- セッション `<id2>` ターン N2: ...
+- セッション `<id1>` (topic: <要約>) ターン N1: 元 "<元プロンプト>" → Claude は <要約> → ユーザー "<修正>"
 
-**改善案 (A. プロンプト書き換え)**:
+**判定根拠**: <例: assistant が「PR 作成しました」直後にユーザーから「task README も含めて」が来た>
+**反証可能性**: <例: 段階的計画の「次ステップ」を誤判定した可能性>
 
+**改善案 (A)**:
 ```
 [元] <元プロンプト>
 [改善後] <具体プロンプト雛形>
 ```
+**運用案 (D)**: 2 回目の補正で `Esc Esc` → 上記改善プロンプトで再開推奨
 
-**運用案 (D. 巻き戻し)**:
-> 2 回目の補正で `Esc Esc` → 上記改善プロンプトで再開推奨
-
-(パターンごとに繰り返し。最大 3 パターン)
-
----
+(最大 3 パターン)
 
 ## 指示違反パターン
 
-### 違反 1: 「<ルール文の要約>」 (<件数>件 / 出典: <CLAUDE.md / SKILL.md / memory>)
+### 違反 1: 「<ルール文>」 (<件数>件 / 出典: <...>)
 
-**事例**:
-- セッション `<id1>` ターン N1: <違反した tool_use 要約 / assistant 応答抜粋>
-- セッション `<id2>` ターン N2: ...
+| セッション | topic | ターン | tool_use 抜粋 | 直前 slash command | 判定 |
+| --- | --- | --- | --- | --- | --- |
+| `<id1>` | <要約> | N1 | <抜粋> | `<command-name>` または なし | 真の違反 / 誤検出（理由） |
 
-**現状のルール文**:
-> <抜粋>
-
-**主因**: <ルール埋没 | 検証なし完了 | rot 起因 | トリガミス>
-
-**改善案 (B. ルール明文化)**:
-
+**現状のルール文**: > <抜粋>
+**判定根拠**: <例: tool_use Bash で `git commit -m ...`、ユーザーが「コミットして」と直前に指示していない>
+**反証可能性**: <例: 直前 N ターン以内に /autodev-create-pr 起動があり template で commit 許可済みなら誤検出>
+**主因**: <ルール埋没 / 検証なし完了 / rot 起因 / トリガミス / 反復指示>
+**改善案 (B)**:
 ```markdown
 <書き換え後の CLAUDE.md / memory ファイル雛形>
 ```
-
-**Hook 化案 (C, 反復が 3 回以上の場合)**:
-
+**Hook 化案 (C, 反復 3 回以上のみ)**:
 ```json
-{
-  "hooks": { ... }
-}
+{ "hooks": { ... } }
 ```
 
-(違反ごとに繰り返し。最大 3 違反。それ以上は「その他の違反」に圧縮)
-
----
+(最大 3 違反。それ以上は「その他の違反」に圧縮)
 
 ## クロスセッション傾向
 
 - 反復違反ルール: <ルール> が <n> セッションで違反 → B + C 推奨
 - 反復手戻りパターン: <パターン> が <n> セッションで再現 → A の雛形プロンプトを CLAUDE.md に追加候補
 - 完了宣言後差し戻し率: <X>%（rework 中の割合）→ Stop Hook 候補
+- post-completion supplement の頻度: <Y> 件 / <N> セッション
 
 ## 統計サマリ
 
-- セッション数: <N>
-- ターン総数: <合計>
-- 手戻り件数: <rework_total>
-- 指示違反件数: <violation_total>
-- ルール抽出元: CLAUDE.md <a> / SKILL.md <b> / memory <c> / system reminder <d>
+- セッション数 <N> / ターン総数 <合計>
+- 手戻り件数 <rework_total>（うち post-completion supplement <p>）
+- 指示違反候補件数 <violation_total>（うち誤検出 <fp> / 真の違反 <real>）
+- 反復追加指示クラスタ数 <K>
+- ルール抽出元: system reminder <s> / `~/.claude/CLAUDE.md` <g> / `<repo>/CLAUDE.md` <p> / memory <m> / SKILL.md <k>
 
 ## 誤検出の可能性
 
 - 否定語含むユーザー入力でも、過去の話題引用なら手戻りではない
 - ルール文が一般的注意であって個別アクションを禁じていない場合は違反ではない
 - 段階的計画の「次ステップ」を完了後差し戻しと誤判定する可能性
-- rot 起因の違反は本スキルの文面改善より先に、コンテキストロット側の対処（断点 / MEMORY 化 / Compact Instructions）を優先
+- **slash command 経由で許可されたアクションを違反扱いした可能性**（4.2.1 の slash command コンテキストガードで除外したもの以外）
+- guarded read (`cat ... 2>/dev/null` 等) を `cat` の不適切利用扱いした可能性
+- rot 起因の違反は文面改善より先にコンテキストロット側の対処（断点 / MEMORY 化 / Compact Instructions）を優先
 
 ## 推奨アクション TOP3
 
-1. **<アクション>** — <1 行の why と how>
-2. **<アクション>** — <1 行の why と how>
-3. **<アクション>** — <1 行の why と how>
+1. **<アクション>** — <1 行 why と how>。対象パス `<具体的なファイル>`、変更概要 <1 行>
+2. ...
+3. ...
 ````
 
 #### TOP3 の優先度
 
 | Tier | 内容 |
 | --- | --- |
-| Tier 1（必ず TOP3） | 同一ルール違反が 3 回以上反復 / 危険コマンド系違反（`--no-verify`, `git push --force`, `rm -rf`） / 完了後差し戻しが 3 回以上 |
+| Tier 1（必ず TOP3） | **クロスセッション反復追加指示が 2 セッション以上で出ている** (F カテゴリ。本スキルの主目的) / 同一ルール違反が 3 回以上反復 / 危険コマンド系違反（`--no-verify`, `git push --force`, `rm -rf`） / 完了後差し戻しが 3 回以上 |
 | Tier 2（影響大なら TOP3） | 補正ループ 2 回以上の単一パターン / 単一セッション違反 5 件以上 / トリガミス起因違反が複数セッションで反復 |
 | Tier 3（運用改善） | 単発の手戻り / 軽微な文面違反 / SKIP 条件追加で済むもの |
 
-判断基準: **書き換え + 1 アクションで複数の手戻り/違反が解消できるもの**を上に。Hook 化（C）は決定論的に効くため反復違反では Tier 1 に上がりやすい。
+判断基準: **書き換え + 1 アクションで複数の手戻り/違反/反復指示が解消できるもの**を上に。F の昇格は**ユーザー側の追加指示コストを永続的にゼロにする**ため Tier 1 として最優先で TOP3 に入れる。
 
 #### finding が少ないとき
 
-検出が 1〜2 件しかないときは、パターン化せず **「気づいたこと」セクション 1 つ + TOP3** に圧縮する。空でも構造を埋めるために finding を水増ししないこと。
+検出が 1〜2 件のときはパターン化せず**「気づいたこと」セクション 1 つ + TOP3** に圧縮。空でも構造を埋めるために finding を水増ししない。クロスセッション反復が 0 件のときも**観測事実として「検出されなかった」を残す**。
 
 ### 8. 実装ヒント
 
-`Bash` で `python3` ヒアドキュメントを使うと一気に集計できる。骨格例:
-
-```python
-import json, glob, os, re
-from collections import defaultdict
-
-SESSIONS = sorted(
-    glob.glob(os.path.expanduser("~/.claude/projects/<encoded-cwd>/*.jsonl")),
-    key=os.path.getmtime, reverse=True
-)[1:11]  # 実行中除外して 10 件
-
-NEG_WORDS = re.compile(
-    r"\b(no|not that|not what I meant|instead|actually|stop|wait|revert|undo)\b"
-    r"|違う|そうじゃ(ない|なくて)|やめて|いや|じゃなくて|戻して|元に戻して",
-    re.IGNORECASE,
-)
-DONE_DECLARATIONS = re.compile(
-    r"\b(done|completed|finished|all set|created the PR)\b|完了しました|終わりました|作成しました",
-    re.IGNORECASE,
-)
-
-def iter_records(path):
-    for line in open(path):
-        try:
-            yield json.loads(line)
-        except json.JSONDecodeError:
-            continue
-
-def user_text(rec):
-    msg = rec.get("message", {})
-    c = msg.get("content")
-    if isinstance(c, str):
-        return c
-    if isinstance(c, list):
-        return "\n".join(b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text")
-    return ""
-
-def assistant_text_and_tools(rec):
-    msg = rec.get("message", {})
-    text_parts = []
-    tools = []
-    for b in msg.get("content", []):
-        if b.get("type") == "text":
-            text_parts.append(b.get("text", ""))
-        elif b.get("type") == "tool_use":
-            tools.append((b.get("name"), b.get("input", {})))
-    return "\n".join(text_parts), tools
-
-def find_rework_events(path):
-    """直近 assistant ターンに対する否定即時返信を抽出。"""
-    last_assistant = None  # (turn_idx, text, tools)
-    last_user = None  # (turn_idx, text)
-    turn_idx = 0
-    events = []
-    for rec in iter_records(path):
-        t = rec.get("type")
-        if t == "assistant":
-            turn_idx += 1
-            text, tools = assistant_text_and_tools(rec)
-            last_assistant = (turn_idx, text, tools)
-        elif t == "user":
-            ut = user_text(rec)
-            if last_assistant and NEG_WORDS.search(ut):
-                events.append({
-                    "turn": last_assistant[0],
-                    "user_original": last_user[1] if last_user else "",
-                    "claude_action": last_assistant[1][:200],
-                    "user_correction": ut[:200],
-                    "post_done": bool(DONE_DECLARATIONS.search(last_assistant[1])),
-                })
-            last_user = (turn_idx, ut)
-    return events
-
-def find_violations(path, rules):
-    """rules: [{'text': ..., 'kind': 'positive'|'negative', 'matcher': callable(tools, asst_text) -> bool}]"""
-    turn_idx = 0
-    violations = []
-    for rec in iter_records(path):
-        if rec.get("type") != "assistant":
-            continue
-        turn_idx += 1
-        text, tools = assistant_text_and_tools(rec)
-        for r in rules:
-            if r["matcher"](tools, text):
-                violations.append({"turn": turn_idx, "rule": r["text"]})
-    return violations
-
-# ルール例: 「--no-verify を使わない」
-rules = [
-    {
-        "text": "git commit --no-verify を使わない",
-        "kind": "negative",
-        "matcher": lambda tools, text: any(
-            name == "Bash" and "--no-verify" in (args.get("command") or "")
-            for name, args in tools
-        ),
-    },
-]
-```
-
-完全実装は不要 — Claude が transcript を読み取り、3 点組の組み立てとパターン化ができれば良い。集計が複雑になりすぎたら**1〜2 セッションだけ手で読み込み**、定性的に finding を作っても十分価値がある（このスキルのゴールは「ユーザーが次の書き換え／運用変更を選べる」こと）。
+`Bash` で `python3` ヒアドキュメントで集計する。完全実装は不要 — Claude が transcript を読み取り、3 点組の組み立てとパターン化、クロスセッションクラスタリングができれば良い。骨格コード・最小サンプル・代替手段（手で目視 + Grep）は `reference/implementation.md` を参照。
 
 ## 注意事項
 
-- **transcript には機密情報が含まれる可能性がある**。レポートに引用する元プロンプトや tool_use 引数にトークン的な値が混入していないか軽くチェックし、疑わしければマスクする（API キー、認証ヘッダ、環境変数ダンプ中の secret 等）
-- **自分自身のセッションを分析しないこと**（ユーザー明示対象時を除く）。mtime 最新の jsonl を実行中セッションとみなして除外する
-- **巨大 JSONL の全文 Read を避ける**。1 ファイル 1MB を超える場合は `python3` ヒアドキュメントでの集計を併用する
-- **ルール抽出は完全ではない**。自然言語の抜粋なので解釈には幅がある。違反判定は複数シグナル（語彙 + tool_use 不在/存在）が揃ったときに「違反候補」のトーンで提示する
-- **誤検出条件を必ず併記**。「補正ループ確定」ではなく「補正ループ候補」、「指示違反確定」ではなく「指示違反候補」を基本トーンに
-- **rot 起因の可能性に注意**: 違反が session 後半に集中、または初期 reminder で示されたルールが消失している場合、本スキルの B/C 改善より先にコンテキストロット側の対処（MEMORY 化 / Compact Instructions / 断点）で根治するケースがある。レポートに「rot 起因の可能性」として併記する
-- **改善提案は具体的に**。「もっと明確に書いてください」「気をつけてください」ではなく**書き換え後の文面 / Hook スニペット / 巻き戻し操作**まで提示する
-- **Hook 化の提案は慎重に**。CLAUDE.md の文面改善で十分なケースで Hook を提案すると運用が重くなる。**3 回以上反復**または**影響が大きい**ケースに限定する
-- **レポートはファイルに書き出し**、画面には TL;DR + TOP3 + パスのみ表示する
+- **transcript には機密情報が含まれる可能性がある**。引用前に API キー / 認証ヘッダ / 環境変数ダンプ中の secret 等が混入していないか軽くチェックし、疑わしければマスクする
+- **自分自身のセッションを分析しない**（ユーザー明示時を除く）。mtime 最新の jsonl を実行中とみなして除外
+- **巨大 JSONL の全文 Read を避ける**。1MB 超は `python3` ヒアドキュメントで集計
+- **ルール抽出は完全ではない**。違反判定は複数シグナルが揃ったときに「違反候補」のトーンで提示
+- **誤検出条件を必ず併記**。「補正ループ確定」ではなく「補正ループ候補」が基本トーン
+- **slash command コンテキストガード必須**（4.2.1）。これを省くと `/autodev-create-pr` 経由のコミット等を毎回違反として誤報告する
+- **post-completion supplement (4.1.e) を見落とさない**。否定語を含まない追加指示は (a) からは漏れるが、ユーザーの軌道修正コストとしては最も高頻度。クロスセッション分析と組み合わせて F カテゴリの主材料にする
+- **rot 起因の可能性に注意**: 違反が session 後半に集中、または初期 reminder のルールが消失している場合、本スキルの B/C 改善より先にコンテキストロット側の対処で根治する
+- **改善提案は具体的に**: 書き換え後の文面 / Hook スニペット / 巻き戻し操作 / memory ファイル雛形 / skill template 修正 diff まで提示
+- **Hook 化は慎重に**: CLAUDE.md の文面改善で十分なケースで Hook を提案すると運用が重くなる。3 回以上反復または影響が大きいケースに限定
+- **F カテゴリの修正対象パスに注意**: `plugins/<plugin>/skills/<skill>/SKILL.md` （配布元）に入れる。`.claude/skills/` の symlink だけ書き換えても他環境に伝わらない
+- **レポートはファイル書き出し**、画面には TL;DR + TOP3 + パスのみ表示

--- a/plugins/agent-coach/skills/detect-rework-and-violations/reference/implementation.md
+++ b/plugins/agent-coach/skills/detect-rework-and-violations/reference/implementation.md
@@ -1,0 +1,318 @@
+# 実装ヒント（Python ヒアドキュメント例）
+
+`Bash` で `python3` ヒアドキュメントを使うと一気に集計できる。完全実装は不要 — Claude が transcript を読み取り、3 点組の組み立てとパターン化、クロスセッションクラスタリングができれば良い。集計が複雑になりすぎたら**1〜2 セッションだけ手で読み込み**、定性的に finding を作っても十分価値がある。
+
+## 骨格
+
+```python
+import json, glob, os, re
+from collections import defaultdict
+
+SESSIONS = sorted(
+    glob.glob(os.path.expanduser("~/.claude/projects/<encoded-cwd>/*.jsonl")),
+    key=os.path.getmtime, reverse=True
+)[1:11]  # 実行中除外して 10 件
+
+NEG_WORDS = re.compile(
+    r"\b(no|not that|not what I meant|instead|actually|stop|wait|revert|undo)\b"
+    r"|違う|そうじゃ(ない|なくて)|やめて|いや|じゃなくて|戻して|元に戻して|やり直し",
+    re.IGNORECASE,
+)
+DONE_DECLARATIONS = re.compile(
+    r"\b(done|completed|finished|all set|created the PR)\b|完了しました|終わりました|作成しました",
+    re.IGNORECASE,
+)
+INSTR_KEYS = re.compile(
+    r"(してください|して下さい|お願い|しないで|避けて|しましょう|ましょう|"
+    r"にして|に変えて|に直して|に変更|追加して|含めて|含めましょう|"
+    r"\bplease\b|\bdon't\b|\bmust\b|\balways\b|\bnever\b|\binstead\b|\balso\b)",
+    re.IGNORECASE,
+)
+
+def iter_records(path):
+    for line in open(path):
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+def user_text(rec):
+    msg = rec.get("message", {})
+    c = msg.get("content")
+    if isinstance(c, str):
+        return c
+    if isinstance(c, list):
+        return "\n".join(b.get("text", "") for b in c if isinstance(b, dict) and b.get("type") == "text")
+    return ""
+
+def is_user_actual_input(rec):
+    """tool_result やローカルコマンド出力ではなく、実ユーザー発話か判定。"""
+    msg = rec.get("message", {})
+    c = msg.get("content")
+    if isinstance(c, list):
+        for b in c:
+            if isinstance(b, dict) and b.get("type") == "tool_result":
+                return False
+    if isinstance(c, str) and ("<local-command-stdout>" in c or "<local-command-stderr>" in c):
+        return False
+    return True
+
+def assistant_text_and_tools(rec):
+    msg = rec.get("message", {})
+    text_parts = []
+    tools = []
+    for b in msg.get("content", []):
+        if not isinstance(b, dict):
+            continue
+        if b.get("type") == "text":
+            text_parts.append(b.get("text", ""))
+        elif b.get("type") == "tool_use":
+            tools.append((b.get("name"), b.get("input", {})))
+    return "\n".join(text_parts), tools
+
+def find_rework_events(path):
+    """否定即時返信 + post-completion supplement を抽出。"""
+    last_assistant = None
+    last_user = None
+    turn_idx = 0
+    events = []
+    for rec in iter_records(path):
+        t = rec.get("type")
+        if t == "assistant":
+            turn_idx += 1
+            text, tools = assistant_text_and_tools(rec)
+            last_assistant = (turn_idx, text, tools)
+        elif t == "user" and is_user_actual_input(rec):
+            ut = user_text(rec)
+            if not ut.strip(): continue
+            if last_assistant:
+                # (a) 否定語ベース
+                if NEG_WORDS.search(ut):
+                    events.append({
+                        "kind": "negation",
+                        "turn": last_assistant[0],
+                        "user_correction": ut[:200],
+                        "post_done": bool(DONE_DECLARATIONS.search(last_assistant[1])),
+                    })
+                # (e) post-completion supplement (否定語なしの追加指示)
+                elif INSTR_KEYS.search(ut) and DONE_DECLARATIONS.search(last_assistant[1]):
+                    events.append({
+                        "kind": "post_completion_supplement",
+                        "turn": last_assistant[0],
+                        "user_supplement": ut[:200],
+                    })
+            last_user = (turn_idx, ut)
+    return events
+
+def find_violations(path, rules, slash_command_frames):
+    """rules: [{'text', 'matcher': callable(name, args, text) -> bool, 'allowed_in_commands': [...] }]
+    slash_command_frames: [(turn, command_name, template_text)]
+    """
+    turn_idx = 0
+    violations = []
+    for rec in iter_records(path):
+        if rec.get("type") != "assistant":
+            continue
+        turn_idx += 1
+        text, tools = assistant_text_and_tools(rec)
+        for r in rules:
+            for name, args in tools:
+                if not r["matcher"](name, args, text):
+                    continue
+                # slash command コンテキストガード
+                cur_frame = next(
+                    (f for f in reversed(slash_command_frames) if f[0] <= turn_idx),
+                    None,
+                )
+                if cur_frame and cur_frame[1] in r.get("allowed_in_commands", []):
+                    continue  # 許可済み
+                violations.append({"turn": turn_idx, "rule": r["text"], "evidence": str(args)[:200]})
+    return violations
+
+# 例: 「コミットは指示時のみ」 + /autodev-create-pr で許可
+rules = [
+    {
+        "text": "コミットはユーザー明示指示時のみ",
+        "matcher": lambda name, args, text: name == "Bash" and "git commit" in (args.get("command","")),
+        "allowed_in_commands": ["/autodev-create-pr", "/autodev-import-review-suggestions"],
+    },
+    {
+        "text": "git commit --no-verify を使わない",
+        "matcher": lambda name, args, text: name == "Bash" and "--no-verify" in (args.get("command","")),
+        "allowed_in_commands": [],  # 常に違反
+    },
+]
+
+# slash command frame の抽出（2 系統: <command-name> と Base directory for this skill:）
+SKILL_BASEDIR_RE = re.compile(r"Base directory for this skill:\s*\S+/skills/([\w\-]+)")
+
+def collect_slash_command_frames(path):
+    """returns [(turn, command_name, full_user_text), ...]
+    <command-name>/<name></command-name> の正規形と、
+    `Base directory for this skill: .../skills/<name>` 形式の自由貼付け版の両方を拾う。
+    """
+    frames = []
+    turn_idx = 0
+    for rec in iter_records(path):
+        t = rec.get("type")
+        if t == "assistant":
+            turn_idx += 1
+            continue
+        if t != "user" or not is_user_actual_input(rec):
+            continue
+        ut = user_text(rec)
+        m_cmd = re.search(r"<command-name>([^<]+)</command-name>", ut)
+        if m_cmd:
+            frames.append((turn_idx, m_cmd.group(1).strip().lstrip("/"), ut))
+            continue
+        m_base = SKILL_BASEDIR_RE.search(ut)
+        if m_base:
+            frames.append((turn_idx, m_base.group(1).strip(), ut))
+    return frames
+
+# 直前ユーザー発話の明示指示チェック（4.2.1 step 4）
+USER_EXPLICIT_INSTR_RE = re.compile(
+    r"(コミット|commit|プッシュ|push|PR|プルリク|task\s*README|README).*(して|しましょう|してください|お願い|please|do)"
+    r"|(して|しましょう|してください|お願い).*(コミット|commit|push|PR)",
+    re.IGNORECASE | re.DOTALL,
+)
+
+def has_user_explicit_instruction(violation_turn, user_messages):
+    """違反ターンの直前 1 ユーザー発話に明示指示が含まれるかチェック。
+    user_messages: [(turn, text), ...] (ユーザー実発話のみ、ターン昇順)
+    """
+    prev = [u for u in user_messages if u[0] <= violation_turn]
+    if not prev: return False
+    return bool(USER_EXPLICIT_INSTR_RE.search(prev[-1][1]))
+```
+
+## クロスセッション反復指示の集約（手順 4.5）の最小実装
+
+```python
+# 候補抽出: 各セッションから 10〜300 文字、命令キー含む user 実発話を集める
+def collect_short_instructions(path):
+    out = []
+    turn_idx = 0
+    for rec in iter_records(path):
+        t = rec.get("type")
+        if t == "assistant":
+            turn_idx += 1
+            continue
+        if t != "user" or not is_user_actual_input(rec):
+            continue
+        ut = user_text(rec).strip()
+        if not (10 <= len(ut) <= 300): continue
+        if ut.startswith("<command-") or "<bash-input>" in ut: continue
+        if not INSTR_KEYS.search(ut): continue
+        out.append({"turn": turn_idx + 1, "text": ut})
+    return out
+
+# 簡易クラスタリング: 文字 4-gram Jaccard >= 0.30 OR 共通キーフレーズ >= 2
+def char_ngrams(s, n=4):
+    s = re.sub(r"\s+", "", s)
+    return {s[i:i+n] for i in range(len(s)-n+1)} if len(s) >= n else set()
+
+def keyphrases(s):
+    # 英数 3 文字以上 / 漢字カナ 3 文字以上を抜く
+    return set(re.findall(r"[A-Za-z][A-Za-z0-9]{2,}|[一-龥ァ-ヶー]{3,}", s))
+
+def cluster_cross_session(all_instr_with_session):
+    """[(session, turn, text), ...] -> [[member, ...], ...]
+    2 セッション以上で出現したクラスタのみ採用。
+    """
+    # 各候補に ngram + keyphrase を計算
+    enriched = [
+        {**x, "ng": char_ngrams(x["text"]), "kp": keyphrases(x["text"])}
+        for x in all_instr_with_session
+    ]
+    clusters = []
+    visited = set()
+    for i, a in enumerate(enriched):
+        if i in visited: continue
+        cluster = [a]; visited.add(i)
+        for j in range(i+1, len(enriched)):
+            if j in visited: continue
+            b = enriched[j]
+            if a["session"] == b["session"]: continue
+            ng_jaccard = len(a["ng"] & b["ng"]) / max(1, len(a["ng"] | b["ng"]))
+            kp_overlap = len(a["kp"] & b["kp"])
+            if ng_jaccard >= 0.30 or kp_overlap >= 2:
+                cluster.append(b); visited.add(j)
+        if len({x["session"] for x in cluster}) >= 2:
+            clusters.append(cluster)
+    clusters.sort(key=lambda c: -len({x["session"] for x in c}))
+    return clusters
+```
+
+## セッショントピックの抽出（手順 1.1）
+
+セッション ID 単独では読み手に意味が伝わらないため、各セッションに 1 行の topic を付ける:
+
+```python
+TOPIC_COMMANDS = {
+    "/autodev-start-new-task", "/autodev-start-new-project", "/autodev-start-new-survey",
+    "/autodev-discussion", "/autodev-create-issue",
+    "/autodev-replan", "/autodev-steering", "/init",
+}
+PR_COMMANDS = {"/autodev-create-pr", "/autodev-import-review-suggestions", "/autodev-review-pr"}
+NOISE_COMMANDS = {"/clear", "/compact", "/help", "/rewind", "/fast"}
+
+def extract_topic(path):
+    """セッショントピック (string, branch) を返す。
+    優先順位: topic-defining コマンドの args > PR 系コマンド + branch名 > その他コマンド > 自由入力先頭。
+    """
+    first_topic = first_pr = first_other = first_freeform = None
+    branch = None
+    for rec in iter_records(path):
+        if rec.get("gitBranch") and not branch:
+            branch = rec.get("gitBranch")
+        if rec.get("type") != "user" or not is_user_actual_input(rec):
+            continue
+        ut = user_text(rec)
+        if not ut: continue
+        m_cmd = re.search(r"<command-name>([^<]+)</command-name>", ut)
+        if m_cmd:
+            cmd = m_cmd.group(1).strip()
+            if cmd in NOISE_COMMANDS: continue
+            m_args = re.search(r"<command-args>([^<]*)</command-args>", ut, re.DOTALL)
+            args = m_args.group(1).strip() if m_args else None
+            if cmd in TOPIC_COMMANDS and not first_topic:
+                first_topic = (cmd, args)
+                break
+            if cmd in PR_COMMANDS and not first_pr:
+                first_pr = (cmd, args)
+            if cmd not in TOPIC_COMMANDS and cmd not in PR_COMMANDS and not first_other:
+                first_other = (cmd, args)
+        else:
+            if (not first_freeform
+                and not re.match(r"^<(local-command|bash-input|bash-stdout|bash-stderr)", ut)
+                and not ut.startswith("Base directory for this skill:")):
+                first_freeform = ut.strip()
+
+    def fmt(ca):
+        cmd, args = ca
+        return f"{cmd} 「{args[:80]}」" if args else cmd
+
+    if first_topic:
+        return fmt(first_topic), branch
+    if first_pr:
+        b_short = (branch or "").split("/")[-1] if branch and branch != "main" else branch
+        return f"{fmt(first_pr)} (branch: {b_short or '-'})", branch
+    if first_other:
+        return fmt(first_other), branch
+    if first_freeform:
+        return first_freeform[:80], branch
+    return "(no topic found)", branch
+```
+
+## さらに簡易な代替（手で十分）
+
+実装が複雑になるなら、**手で目視 + Grep** で十分:
+
+```bash
+grep -h '<bash-input>\|<command-' -v <session-files> \
+  | grep -E '(してください|しましょう|please|don'\''t)' \
+  | sort -u
+```
+
+10 セッション 50〜100 候補なら 5 分で読める。

--- a/plugins/agent-coach/skills/detect-rework-and-violations/reference/promotion-templates.md
+++ b/plugins/agent-coach/skills/detect-rework-and-violations/reference/promotion-templates.md
@@ -1,0 +1,93 @@
+# 反復指示の昇格テンプレ集（改善カテゴリ F）
+
+クロスセッション反復追加指示を検出したとき、以下のいずれかの昇格先に書き出す。SKILL.md 本体の手順 6-F から参照される。
+
+## F-1. memory ファイル化（feedback type）
+
+ユーザー個人の好み / プロジェクト固有の運用ルールが session 横断で繰り返される場合、`~/.claude/projects/<encoded-cwd>/memory/<name>.md` に書き出す（プロジェクト依存ならこのパス、リポジトリ非依存なら `~/.claude/memory/`）。
+
+雛形:
+
+```markdown
+---
+name: <短い名前>
+description: <一行説明>
+type: feedback
+---
+
+<ルール本文>
+
+**Why:** <反復している証拠（セッション ID とターン番号 2 件以上）>。
+**How to apply:** <どの局面で何をするか / 何をしないか>。
+```
+
+実例（試用で見つかった反復指示「PR タイトル/本文を日本語に」を昇格する場合）:
+
+```markdown
+---
+name: pr-language
+description: PR タイトル・本文・コミットメッセージは日本語で書く（このリポジトリのプロジェクト言語）
+type: feedback
+---
+
+このリポジトリでは PR タイトル / 本文 / コミットメッセージを日本語で書く。
+
+**Why:** /autodev-create-pr 直後にユーザーが「日本語にしてください」と追加指示を入れた事例が複数セッションで観測された（例: 301d1256 t118 / 4203e1e9 t76）。
+**How to apply:** /autodev-create-pr 実行時、CLAUDE.md / steering ドキュメントが日本語であることを確認し、日本語で本文を生成する。
+```
+
+## F-2. プロジェクト CLAUDE.md への昇格
+
+プロジェクト全体の運用ルールであれば `<repo>/CLAUDE.md` の冒頭近くに「IMPORTANT — must follow」として追加。`B. ルール明文化` の雛形と同形式:
+
+```markdown
+# プロジェクト名
+
+## IMPORTANT — must follow
+
+- <ルール本文>
+  - **Why:** <反復している証拠>
+  - **How to apply:** <どこで効かせるか>
+```
+
+## F-3. slash command / skill template の修正
+
+特定の slash command（`/autodev-create-pr` など）の挙動を補正する追加指示が反復している場合は、**skill 本体の手順に組み込む**のが最も効果的。advisory な memory より skill 内の手順のほうが decisive。
+
+修正対象の決定:
+
+1. ユーザー環境で動いている skill 実体は通常 `plugins/<plugin>/skills/<skill>/SKILL.md` （配布元）
+2. 本リポジトリ内では `plugins/autodev/skills/autodev-init/templates/skills/<skill>/SKILL.md` （新規セットアップで展開されるテンプレート）も合わせて修正する
+3. 該当 skill の手順本文に、反復指示の内容を**最初から含めた手順**として書き込む
+
+実例（試用で見つかった反復指示「task README の更新も PR に含める」を昇格する場合）:
+
+```diff
+ # /autodev-create-pr 手順
+ ...
+ 1. git status / git diff / git log で差分を把握
++   - 特に `.ai-agent/tasks/<task-name>/README.md` に未コミット変更があれば、本 PR に含める
++     （タスクの完了条件チェックや PR URL 反映を毎回ユーザーに追加指示させない）
+ 2. 差分から PR タイトル・本文を起こす
++   - PR タイトル・本文の言語は CLAUDE.md / steering ドキュメントの言語に合わせる
+ 3. ...
+```
+
+## F-4. グローバル `~/.claude/CLAUDE.md` への昇格
+
+リポジトリ非依存な好み（出力スタイル、口調、tool 使用方針）は `~/.claude/CLAUDE.md` に追加。雛形は B と同形式だが Why に「複数リポジトリで反復」を書く。
+
+## F カテゴリ提案時の注意
+
+- **必ず昇格先を 1 つだけ提案**（複数候補があれば優先順位を 1 行で説明）。複数の昇格先が同時に提案されるとユーザーが選択コストを負う
+- 反復指示の **証拠（セッション ID + ターン番号）** を最低 2 件添える。1 件しかない反復は F の対象ではなく単発の手戻り (A 系) で扱う
+- **ユーザーの環境で実体が読み込まれるパスに修正を入れる**こと。本リポジトリで開発している skill は `plugins/<plugin>/skills/<skill>/SKILL.md` が配布元、ユーザー機ではマーケットプレイス経由のインストール先が実体。`.claude/skills/` の symlink は本リポジトリ自体の試用用なので、ここだけ書き換えても他環境には伝わらない
+
+## 昇格先の選択基準
+
+| 内容のタイプ | 昇格先 |
+| --- | --- |
+| プロジェクト固有の運用ルール（PR の言語、コミット粒度、ブランチ命名） | F-1 memory（projects 配下）または F-2 プロジェクト CLAUDE.md |
+| ユーザー個人の好み（出力スタイル、口調、レポート形式） | F-1 memory（リポジトリ非依存）または F-4 グローバル CLAUDE.md |
+| 特定 skill / slash command の挙動補正（PR 文面、タスク README 取り込み等） | **F-3 skill template の修正**（最強。手順に組み込めば二度と追加指示が要らない） |
+| 単発タスク特有の文脈 | 昇格不要 |


### PR DESCRIPTION
## 目的

`detect-rework-and-violations` スキルを実際の transcript に対して試用し、

1. 手順通りに実行できるか（手順の曖昧さ・不足の検出）
2. 検出される手戻り・違反の判定が妥当か（誤検出率の評価）
3. レポートが分析過程を知らない人にも分かるか（読解性の評価）
4. 「追加指示の最小化」というスキルの主目的に直結する機能（クロスセッションで毎回反復している追加指示の検知）が組み込まれているか

を評価し、検出された問題点を SKILL.md に反映した。さらに、本会話のコンテキストを持たない fresh エージェントを team member として spawn して同一 10 セッションで再試用し、独立評価で改善を確認したうえで残改善点も取り込んだ。

## 変更概要

### 検出機能の拡張

- **クロスセッション反復追加指示の検知（手順 4.5）を新設**: 短〜中程度のユーザー追加指示（命令キーを含むもの）を全セッションから集め、文字 4-gram Jaccard + キーフレーズ一致でクラスタ化、≥2 セッションで反復するクラスタを抽出する。本スキルの主目的「追加指示の最小化」に直結する中心機能。
- **改善カテゴリ F「反復指示の昇格」を新設**: 検出した反復指示クラスタを memory ファイル化 (F-1) / プロジェクト CLAUDE.md (F-2) / **slash command / skill template の修正 (F-3)** / グローバル CLAUDE.md (F-4) のいずれかに昇格させる雛形と選択基準を提示。
- **手戻りシグナルに post-completion supplement (4.1.e) を追加**: 否定語を含まない「完了宣言寸前の追加指示」を捕捉。日本語話者の建設的口調の追加指示が NEG_WORDS ベースだけでは漏れていた問題を解消（試用時 0 件 → fresh 評価で 2 件検出）。
- **slash command コンテキストガード (4.2.1) を必須化**: `<command-name>` および `Base directory for this skill: .../skills/<name>` 形式の両方で frame を抽出し、template が許可しているアクションは違反扱いしない。`/autodev-create-pr` 経由のコミット等の誤検出を抑制（試用時 14/14 誤検出 → fresh 評価で 5/12 誤検出を自動除外）。
- **直前ユーザー発話の明示指示チェック (4.2.1 step 4) を追加**: 「コミットして」「PR にしましょう」のような直前ユーザー発話を違反候補から除外。

### レポート読解性の改善

- **セッショントピック抽出 (手順 1.1) を新設**: UUID だけでは読み手が中身を識別できない問題を解消。各セッションに `/autodev-start-new-task「<args 抜粋>」` 形式の topic を抽出してレポート全体（事例リスト・反復指示クラスタ・統計サマリ）に併記。
- **レポート雛形を強化**: 各 finding に「判定根拠」「反証可能性」を必須化。TL;DR の主因内訳に専門用語の 1 行注釈（「rot 起因 = ...」など）を併記。推奨アクションは具体的対象パスまで書き出す。レポート最初に「セッション一覧（読解用）」テーブルを配置。
- **TOP3 優先度の Tier 1 に「クロスセッション反復追加指示」を最優先追加**: スキルの主目的に直結する成果として最優先で出す。

### 構造改善（公式 SKILL.md ≤ 500 行 tip に準拠）

- 詳細リソースを `reference/` 配下に切り出し:
  - `reference/promotion-templates.md` — F カテゴリの memory ファイル / CLAUDE.md / slash command template 修正の雛形と実例集
  - `reference/implementation.md` — Python ヒアドキュメント実装の骨格（rework 検出 / 違反検出 + slash command ガード / topic 抽出 / クロスセッションクラスタリング / 直前ユーザー発話の明示指示チェック）
- SKILL.md 本体は 512 行（試用前 515 → 改修途中 746 → 切り出し後 512）。

### 試用成果物（gitignore 配下）

`.ai-agent/tmp/20260506-rework-violations/` に旧版・改修版の試用レポート 2 本（`report.md` / `report-fresh.md`）と分析スクリプト (`analyze.py` / `cross_session.py`) を残してある。本 PR には含まれない（`.ai-agent/tmp/` は gitignore）。

## fresh エージェント評価で発見された別タスク種

本評価の過程で、本リポジトリ自体にも対処すべき問題が見つかった。**本 PR のスコープ外**だが、別タスクの種としてここに記録する:

1. **`/autodev-create-pr` を毎回呼ぶべきところで Claude が直接 `git commit + push + gh pr create` で代替している** (5 セッション横断のトリガミス)。`plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md` L80-81 の「`/autodev-create-pr` を使用する」を強い文言（「**必ず slash command を起動する**」）に書き換える別 PR が必要。
2. **PR 作成完了後にユーザーが「task README も含めて」「PR を日本語に」と毎回追加指示している** (post-completion supplement, 2 セッション横断)。`plugins/autodev/skills/autodev-init/templates/skills/autodev-create-pr/SKILL.md` の手順本文に取り込むべき (F-3 反復指示の昇格)。

これらは本 PR のスキル定義改善とは独立した別タスクで対応する。

## Test plan

- [x] `python3 scripts/validate-skills.py` → 23 ファイル 0 error
- [x] 試用評価を実施（最新 10 セッション、`.ai-agent/tmp/20260506-rework-violations/report.md`）
- [x] fresh エージェントによる独立試用で改善確認（同 10 セッション、`report-fresh.md`）
- [x] レポート可読性: fresh エージェント自己評価で「事前知識ゼロでも手順 1〜7 を完走可能」と確認
- [x] 反復指示クラスタ 2 種を誤検出ゼロで検出（task README / PR 言語）
- [x] slash command ガードで 12 件中 5 件を自動除外、誤検出率 42% を抑制
