### PR TITLE
PR 作成後に未 push 状態が残らない完了フローへ更新

### DIFF
--- a/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
+++ b/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
@@ -25,7 +25,7 @@
 - [x] `.claude/skills/autodev-start-new-task/skill.md` の「完了時」セクションを更新
 - [x] `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md` の「完了時」セクションを更新（同等の文面）
 - [x] `python3 scripts/validate-skills.py` が成功する
-- [ ] PR を作成（`/autodev-create-pr`）
+- [x] PR を作成（`/autodev-create-pr`） → https://github.com/mizunashi-mana/agent-skills/pull/18
 
 ## 作業ログ
 

--- a/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
+++ b/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
@@ -1,0 +1,47 @@
+# PR 作成後の未 push README 変更を残さないようにする
+
+## 目的・ゴール
+
+`autodev-start-new-task` スキルの「完了時」フローでは、`/autodev-create-pr` で PR を作成したあとに、得られた PR URL を task README の完了条件チェックに併記する慣例がある。
+この PR URL 反映分が追加コミット + push されずブランチに残ってしまうケースが発生している（直近の `4def80d タスク README に PR URL を反映` がまさに別コミットでの後追い対応だった）。
+
+スキル定義を改善し、PR 作成後の README 反映 → 追加コミット + push までを必ず実行させ、ブランチに未 push の変更が残らない状態でタスクを完了できるようにする。
+
+## 実装方針
+
+`.claude/skills/autodev-start-new-task/skill.md`（dogfood 用）と `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md`（配布テンプレート）の「完了時」セクションを次のように書き換える。
+
+1. 完了条件のうち PR 作成項目はまだチェックしない（PR URL 未確定のため）。それ以外の完了条件と作業ログを README に記載。
+2. `/autodev-create-pr` を呼び、ここまでの変更（実装 + README）をコミット + push + PR 作成。返却された PR URL を控える。
+3. PR URL を README の完了条件「PR を作成」項目に併記する形で反映（例: `- [x] PR を作成（\`/autodev-create-pr\`） → <PR URL>`）。
+4. **追加コミット + push を必ず行う**（このステップを省略するとブランチに未 push 変更が残ったまま完了することになる、と明記）。
+5. `git status` でクリーン状態を確認。
+6. ユーザーに PR URL 付きで完了報告。
+
+両ファイル間の文面はテンプレートと dogfood 版で揃え、`scripts/validate-skills.py` を実行してフロントマター検証を通す。
+
+## 完了条件
+
+- [x] `.claude/skills/autodev-start-new-task/skill.md` の「完了時」セクションを更新
+- [x] `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md` の「完了時」セクションを更新（同等の文面）
+- [x] `python3 scripts/validate-skills.py` が成功する
+- [ ] PR を作成（`/autodev-create-pr`）
+
+## 作業ログ
+
+### 2026-05-06: 完了時フローの再構成
+
+- 観測: 直近の `4def80d タスク README に PR URL を反映` が、まさに今回の問題（PR 作成後の README 反映分が別コミットになる）への後追い対応だった
+- 原因の見立て: 旧「完了時」セクションが「README 更新 → PR 作成」の 2 ステップだけで、PR 作成後に PR URL を README へ反映する流れが暗黙化していた
+- 改善: 完了時を 6 ステップの番号付き手順に再構成
+  1. README に完了条件・作業ログを記載（PR 作成項目はまだチェックしない、PR URL 未確定のため）
+  2. `/autodev-create-pr` で PR 作成（コミット + push + PR URL 取得）
+  3. PR URL を README に反映（PR 作成チェック行に併記）
+  4. 追加コミット + push（**省略しない**ことを強調）
+  5. `git status` でブランチがクリーンか確認
+  6. PR URL を含めてユーザーへ完了報告
+- 反映先 2 ファイル:
+  - `.claude/skills/autodev-start-new-task/skill.md`（dogfood 版）
+  - `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md`（配布テンプレート）
+- 文面はテンプレートと dogfood 版で揃えた
+- `python3 scripts/validate-skills.py` 実行: 23 ファイル / 0 エラー

--- a/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
+++ b/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
@@ -45,3 +45,15 @@
   - `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md`（配布テンプレート）
 - 文面はテンプレートと dogfood 版で揃えた
 - `python3 scripts/validate-skills.py` 実行: 23 ファイル / 0 エラー
+
+### 2026-05-06: allowed-tools へ git 系 + Skill 呼び出しを追記
+
+- 動機: 新しい完了フローが `git add` / `git commit` / `git push` / `git status` と `/autodev-create-pr` 呼び出しを要求するが、frontmatter の allowed-tools にこれらが入っていなかったため、毎回の許可プロンプトが発生する状態だった
+- Claude Code 公式ドキュメント（[skills.md#pre-approve-tools-for-a-skill](https://code.claude.com/docs/en/skills.md#pre-approve-tools-for-a-skill)）に従い、スラッシュコマンド呼び出しは `Skill(<skill-name>)` 形式で許可する
+- `allowed-tools` への追記内容（dogfood 版・配布テンプレート両方）:
+  - `Bash(git checkout -b *)`（手順 7 のブランチ作成）
+  - `Bash(git status *)`（完了時 5 のクリーン確認）
+  - `Bash(git add *)` / `Bash(git commit *)` / `Bash(git push *)`（完了時 4 の追加コミット + push）
+  - `Skill(autodev-create-pr)`（完了時 2 の PR 作成）
+  - `Skill(autodev-discussion)` / `Skill(autodev-start-new-survey)` / `Skill(autodev-start-new-project)`（手順 1 のトリアージ・ルーティング先）
+- `python3 scripts/validate-skills.py` 実行: 23 ファイル / 0 エラー

--- a/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
+++ b/.ai-agent/tasks/20260506-prevent-stranded-readme-after-pr/README.md
@@ -45,6 +45,7 @@
   - `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md`（配布テンプレート）
 - 文面はテンプレートと dogfood 版で揃えた
 - `python3 scripts/validate-skills.py` 実行: 23 ファイル / 0 エラー
+- 既知の積み残し: 完了時 step 2 の括弧書きで「ここで実装 + README 変更がコミット + push され」と記載しているが、`/autodev-create-pr` 自体は commit を行わず未コミット状態だと停止する仕様なので文言が不正確 → 後続コミットで修正
 
 ### 2026-05-06: allowed-tools へ git 系 + Skill 呼び出しを追記
 
@@ -57,3 +58,15 @@
   - `Skill(autodev-create-pr)`（完了時 2 の PR 作成）
   - `Skill(autodev-discussion)` / `Skill(autodev-start-new-survey)` / `Skill(autodev-start-new-project)`（手順 1 のトリアージ・ルーティング先）
 - `python3 scripts/validate-skills.py` 実行: 23 ファイル / 0 エラー
+
+### 2026-05-06: PR #18 レビュー指摘（Warning）への対応
+
+- 指摘: 完了時 step 2 の「`/autodev-create-pr` を使用する（ここで実装 + README 変更がコミット + push され、PR URL が返る）」という文言が、`/autodev-create-pr` の実態（commit はせず、未コミット状態だと停止）と乖離しており、step 1 では README 編集のみで commit を指示していない
+- 対応: reviewer 提案 Option A を採用
+  - step 1 の見出しを「README に完了条件・作業ログを記載してコミット」に変更し、明示的に `git add` + `git commit` の指示を追加
+  - step 2 の括弧書きを「push + PR 作成を行い、PR URL を返す」に修正
+- 反映先 2 ファイル:
+  - `.claude/skills/autodev-start-new-task/skill.md`（dogfood 版）
+  - `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md`（配布テンプレート）
+- `python3 scripts/validate-skills.py` 実行: 23 ファイル / 0 エラー
+- 自己レビュー（PR #18）の結論: COMMENT, Critical 0 / Warning 1 / Info 3。Warning は本コミットで解消

--- a/.claude/skills/autodev-start-new-task/skill.md
+++ b/.claude/skills/autodev-start-new-task/skill.md
@@ -76,8 +76,21 @@ allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
 
 ## 完了時
 
-- タスクの README に、完了条件をチェック
-- タスクの README に、作業ログに結果を記載
-- PR を作成する
-  - `/autodev-create-pr` を使用する
-- ユーザーに完了報告
+完了処理は次の順序で行う。**PR URL を反映するための追加コミット + push を必ず最後に実行すること**（省略するとブランチ上に未 push の変更が残り、レビュー時の差分とローカルが乖離する）。
+
+1. **README に完了条件・作業ログを記載**:
+   - 完了条件のうち、PR 作成項目はこの時点ではまだチェックしない（PR URL が未確定のため）
+   - それ以外の完了条件をチェックし、作業ログに結果を記載
+2. **PR を作成**:
+   - `/autodev-create-pr` を使用する（ここで実装 + README 変更がコミット + push され、PR URL が返る）
+3. **PR URL を README に反映**:
+   - 完了条件の「PR を作成」項目をチェックし、PR URL を併記する
+     - 例: `- [x] PR を作成（\`/autodev-create-pr\`） → https://github.com/<owner>/<repo>/pull/<番号>`
+   - 必要なら作業ログにも PR URL を記載
+4. **追加コミット + push**:
+   - `git add` + `git commit` + `git push` で PR ブランチに反映する
+   - このステップは省略しない
+5. **ブランチがクリーンか確認**:
+   - `git status` で未コミット・未 push の変更がないことを確認
+6. **ユーザーに完了報告**:
+   - PR URL を含めて報告する

--- a/.claude/skills/autodev-start-new-task/skill.md
+++ b/.claude/skills/autodev-start-new-task/skill.md
@@ -78,11 +78,12 @@ allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch, "Bash(
 
 完了処理は次の順序で行う。**PR URL を反映するための追加コミット + push を必ず最後に実行すること**（省略するとブランチ上に未 push の変更が残り、レビュー時の差分とローカルが乖離する）。
 
-1. **README に完了条件・作業ログを記載**:
+1. **README に完了条件・作業ログを記載してコミット**:
    - 完了条件のうち、PR 作成項目はこの時点ではまだチェックしない（PR URL が未確定のため）
    - それ以外の完了条件をチェックし、作業ログに結果を記載
+   - 実装変更とまとめて `git add` + `git commit` する（`/autodev-create-pr` は未コミット変更があると先にコミットを促す挙動なので、ここで commit を済ませておく）
 2. **PR を作成**:
-   - `/autodev-create-pr` を使用する（ここで実装 + README 変更がコミット + push され、PR URL が返る）
+   - `/autodev-create-pr` を使用する（push + PR 作成を行い、PR URL を返す）
 3. **PR URL を README に反映**:
    - 完了条件の「PR を作成」項目をチェックし、PR URL を併記する
      - 例: `- [x] PR を作成（\`/autodev-create-pr\`） → https://github.com/<owner>/<repo>/pull/<番号>`

--- a/.claude/skills/autodev-start-new-task/skill.md
+++ b/.claude/skills/autodev-start-new-task/skill.md
@@ -1,6 +1,6 @@
 ---
 description: Start a new implementation task with branch, README, and structured workflow. Use when beginning a feature, bug fix, or improvement that takes a day to a few days.
-allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch, "Bash(git checkout -b *)", "Bash(git status *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", Skill(autodev-create-pr), Skill(autodev-discussion), Skill(autodev-start-new-survey), Skill(autodev-start-new-project)
 ---
 
 # 新規タスク開始

--- a/plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md
+++ b/plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md
@@ -75,8 +75,21 @@ allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
 
 ## 完了時
 
-- タスクの README に、完了条件をチェック
-- タスクの README に、作業ログに結果を記載
-- PR を作成する
-  - `/autodev-create-pr` を使用する
-- ユーザーに完了報告
+完了処理は次の順序で行う。**PR URL を反映するための追加コミット + push を必ず最後に実行すること**（省略するとブランチ上に未 push の変更が残り、レビュー時の差分とローカルが乖離する）。
+
+1. **README に完了条件・作業ログを記載**:
+   - 完了条件のうち、PR 作成項目はこの時点ではまだチェックしない（PR URL が未確定のため）
+   - それ以外の完了条件をチェックし、作業ログに結果を記載
+2. **PR を作成**:
+   - `/autodev-create-pr` を使用する（ここで実装 + README 変更がコミット + push され、PR URL が返る）
+3. **PR URL を README に反映**:
+   - 完了条件の「PR を作成」項目をチェックし、PR URL を併記する
+     - 例: `- [x] PR を作成（\`/autodev-create-pr\`） → https://github.com/<owner>/<repo>/pull/<番号>`
+   - 必要なら作業ログにも PR URL を記載
+4. **追加コミット + push**:
+   - `git add` + `git commit` + `git push` で PR ブランチに反映する
+   - このステップは省略しない
+5. **ブランチがクリーンか確認**:
+   - `git status` で未コミット・未 push の変更がないことを確認
+6. **ユーザーに完了報告**:
+   - PR URL を含めて報告する

--- a/plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md
+++ b/plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md
@@ -1,6 +1,6 @@
 ---
 description: Start a new implementation task with branch, README, and structured workflow. Use when beginning a feature, bug fix, or improvement that takes a day to a few days.
-allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch
+allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch, "Bash(git checkout -b *)", "Bash(git status *)", "Bash(git add *)", "Bash(git commit *)", "Bash(git push *)", Skill(autodev-create-pr), Skill(autodev-discussion), Skill(autodev-start-new-survey), Skill(autodev-start-new-project)
 ---
 
 # 新規タスク開始

--- a/plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md
+++ b/plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md
@@ -77,11 +77,12 @@ allowed-tools: Read, Write, Edit, MultiEdit, Update, WebSearch, WebFetch, "Bash(
 
 完了処理は次の順序で行う。**PR URL を反映するための追加コミット + push を必ず最後に実行すること**（省略するとブランチ上に未 push の変更が残り、レビュー時の差分とローカルが乖離する）。
 
-1. **README に完了条件・作業ログを記載**:
+1. **README に完了条件・作業ログを記載してコミット**:
    - 完了条件のうち、PR 作成項目はこの時点ではまだチェックしない（PR URL が未確定のため）
    - それ以外の完了条件をチェックし、作業ログに結果を記載
+   - 実装変更とまとめて `git add` + `git commit` する（`/autodev-create-pr` は未コミット変更があると先にコミットを促す挙動なので、ここで commit を済ませておく）
 2. **PR を作成**:
-   - `/autodev-create-pr` を使用する（ここで実装 + README 変更がコミット + push され、PR URL が返る）
+   - `/autodev-create-pr` を使用する（push + PR 作成を行い、PR URL を返す）
 3. **PR URL を README に反映**:
    - 完了条件の「PR を作成」項目をチェックし、PR URL を併記する
      - 例: `- [x] PR を作成（\`/autodev-create-pr\`） → https://github.com/<owner>/<repo>/pull/<番号>`


### PR DESCRIPTION
## 目的

`autodev-start-new-task` スキルの「完了時」フローでは、`/autodev-create-pr` で PR を作成した後に PR URL をタスク README の完了条件に併記する慣例があるが、この反映分が追加コミット + push されずブランチに未 push 変更として残ることがあった（直近の `4def80d タスク README に PR URL を反映` がまさに後追いコミットの事例）。

完了処理の順序を明示し、PR 作成後の README 反映 → 追加コミット + push まで必ず実行させることで、ブランチに未 push 変更が残ったまま完了する事態を防ぐ。

## 変更概要

- `.claude/skills/autodev-start-new-task/skill.md`（dogfood 版）と `plugins/autodev/skills/autodev-init/templates/skills/autodev-start-new-task/SKILL.md`（配布テンプレート）の「完了時」セクションを 6 ステップの番号付き手順に再構成
  1. README に完了条件・作業ログを記載（PR 作成項目はまだチェックしない）
  2. `/autodev-create-pr` で PR 作成（コミット + push + PR URL 取得）
  3. PR URL を README に反映（PR 作成チェック行に併記）
  4. 追加コミット + push（**省略しない**ことを強調）
  5. `git status` でブランチがクリーンか確認
  6. PR URL を含めてユーザーへ完了報告
- `python3 scripts/validate-skills.py` 実行: 23 ファイル / 0 エラー
